### PR TITLE
Fixed composite studio extension for multiple namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 -
 
+## [1.0.3] - 2022-07-19
+### Fixed
+- #21: Fixes an issue on older IRIS versions in which embedded SQL would cause CodeTidy extension code to run in other namespaces
+
 ## [1.0.2] - 2022-06-23
 ### Fixed
 - #13: ##class(pkg.isc.codetidy.Utils).Configure() defaults to current settings

--- a/cls/pkg/isc/codetidy/extension/CompositeMethodOverrides.cls
+++ b/cls/pkg/isc/codetidy/extension/CompositeMethodOverrides.cls
@@ -271,7 +271,11 @@ ClassMethod FindNamespaceForInternalName(pInternalName As %String) As %String
 		quit tNamespace
 	}
 	
-	set tSettings = ##class(pkg.isc.codetidy.extension.UniversalSettings).%Get(.tSC)
+	try {
+		set tSettings = ##class(pkg.isc.codetidy.extension.UniversalSettings).%Get(.tSC)
+	} catch e { // we are running in a namespace without CodeTidy - eg, when compiling embedded SQL
+		set tSC = e.AsStatus()
+	}
 	if $$$ISERR(tSC) || 'tSettings.MappedSourceControl {
 		quit tNamespace
 	}

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="IRIS" version="26">
 <Document name="isc.codetidy.ZPM"><Module>
   <Name>isc.codetidy</Name>
-  <Version>1.0.2</Version>
+  <Version>1.0.3</Version>
   <Packaging>module</Packaging>
   <Resource Name="pkg.isc.codetidy.PKG" />
   <Resource Name="pkg.isc.codetidy.CodeTidy.INC" />


### PR DESCRIPTION
Fixes #20 

I'm not able to replicate the issue consistently, so using the following to test:
```
// in a namespace with CodeTidy
set s = ##class(pkg.isc.codetidy.extension.Composite).%New($listbuild("","","",""))
w s.FindNamespaceForInternalName("Sample.Class.cls")
USER
// switch to a namespace without CodeTidy
zn "%SYS"
set s = ##class(pkg.isc.codetidy.extension.Composite).%New($listbuild("","","",""))
w s.FindNamespaceForInternalName("Sample.Class.cls")
%SYS
```
Behavior without this change is to throw an error:
```
<CLASS DOES NOT EXIST>zFindNamespaceForInternalName+5^pkg.isc.codetidy.extension.CompositeMethodOverrides.1 *pkg.isc.codetidy.extension.UniversalSettings
```
