### PR TITLE
Add Version checking for $system.SQL.Explain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - 1.1.x]
+## [1.1.0] - 2022-12-06
 
 ### Added 
 - Automatic tweaks have been reintroduced (after being removed due to breaking issues)
 - Pulled in a variety of minor changes from internal development
-
-### Changed
-- 
 
 ### Fixed
 - Bracket matching for automatic tweaks now works
@@ -20,15 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit tests described in module.xml
 - Added unit tests!
 - module.xml works with latest package manager version(s) and git-source-control - for some reason, Directory is needed. (This smells like a package manager bug, but the change is backward-compatible.)
-
-### Security
--
-
-### Removed
--
-
-### Deprecated
--
+- Fixed `<UNDEFINED>` error parsing triggers
+- Fixed SQL plan options for earlier IRIS version without $System.SQL.Explain (#25)
 
 ## [1.0.3] - 2022-07-19
 ### Fixed

--- a/cls/pkg/isc/codetidy/CodeTidy.cls
+++ b/cls/pkg/isc/codetidy/CodeTidy.cls
@@ -79,7 +79,7 @@ ClassMethod Class(pClassName As %String, pSaveChanges = 0) As %Status
 			do triggerStream.WriteLine($piece(triggerDefinition.Code, $char(13, 10) , lineNumber) )
 		}
 		// Process the stream
-		do ..ProcessStream(triggerStream, triggerDefinition.Language, sqlSchemaName, "Trigger:" _ ClassName _ ":" _ triggerDefinition.Name)
+		do ..ProcessStream(triggerStream, triggerDefinition.Language, sqlSchemaName, "Trigger:" _ pClassName _ ":" _ triggerDefinition.Name)
 		// and copy from stream back to string
 		do triggerStream.Rewind()
 		set triggerString = ""
@@ -920,7 +920,14 @@ ClassMethod GetSQLPlan(ByRef SQL As %String, Schema As %String, Output Plan As %
 		set packages = ""
 		if Schema '= "" set packages = packages _ $listbuild(Schema)
 		if Schema '= "SQLUser" set packages = packages _ $listbuild("SQLUser")
-		do $system.SQL.Explain(.sql, {"quiet":1, "preparse":1, "selectmode":1}, , .%plan)
+
+		// Version detection as $system.SQL.ShowPlan is now deprecated
+		if $$$comMemberDefined("%System.SQL", $$$cCLASSmethod, "Explain") {
+			do $system.SQL.Explain(.sql, {"quiet":1, "preparse":1, "selectmode":1}, , .%plan)
+		}
+		else {
+			do $system.SQL.ShowPlan(.sql, 1, 0, packages, , , , , 1)
+		}
 		
 		// Check for plan
 		if $data(%plan(1)) {

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="IRIS" version="26">
 <Document name="isc.codetidy.ZPM"><Module>
   <Name>isc.codetidy</Name>
-  <Version>1.1.0+snapshot</Version>
+  <Version>1.1.0</Version>
   <Packaging>module</Packaging>
   <Resource Name="pkg.isc.codetidy.PKG" Directory="cls" />
   <Resource Name="pkg.isc.codetidy.CodeTidy.INC" Directory="inc" />


### PR DESCRIPTION
Versions of IRIS in some applications do not have the method $system.SQL.Explain and instead use $system.SQL.ShowPlan.

Fixes #25 