### PR TITLE
CodeTidy with JSON linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2023-01-18
+
+### Fixed
+- JSON linting and bracket matching now working
+- Fixed preserving indentation of embedded HTML and block comments
+- Fixed parsing of custom markers for embedded block open/close brackets
+- Removed expansion of "&js<" to "&javascript" and fixed parsing of "&js<"
+- Fixed indentation inconsistencies when user inputs mix of spaces and tabs
+
 ## [1.1.1] - 2022-12-06
 
 ### Fixed

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -568,6 +568,9 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
         while $listnext(lineTokens,pointer,token) {
             set $ListBuild(lang, type, fragment) = token
             set newLineTokens = newLineTokens _ $ListBuild(token)
+            if 'isJSON {
+                set oneDimArray = 1
+            }
 
             #; Handle special rules for line breaks/removing white space
             #; for JSON brackets and delimiters. 
@@ -611,6 +614,8 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
                             set newLineTokens = ""
                         }
                     }
+                } elseif (fragment = "]") {
+                    do $i(isJSON,-1)
                 }
             } elseif type '= "White Space"{
                 set nextToken = ..NextNonWhitespaceToken(.tokens,line,lineTokens,pointer,.nextLine,.nextLineTokens,.nextPointer)

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -293,7 +293,8 @@ ClassMethod IndentDocument(InternalName As %String) As %Status
                 // Get the tokens for each line so that the command can be determined
                 if (method.Language = $$$langObjectScript) || (method.Language = "") {
                     kill tokens
-                    $$$ThrowOnError(##class(pkg.isc.codetidy.vartyping.ObjectScriptTokenizer).GetMethodImplementation(classDef.Name, method.Name, .tokens, $namespace))
+                    $$$ThrowOnError(##class(pkg.isc.codetidy.vartyping.ObjectScriptTokenizer).GetMethodImplementation(classDef.Name, method.Name, .tmpTokens, $namespace))
+                    do ..JSONLint(.tmpTokens,method.Implementation,.tokens)
                     do method.Implementation.Rewind()
                 }
 
@@ -424,6 +425,7 @@ ClassMethod IndentDocument(InternalName As %String) As %Status
             if (language = $$$langObjectScript) || (language = "") {
                 kill tokens
                 $$$ThrowOnError(##class(pkg.isc.codetidy.vartyping.ObjectScriptTokenizer).GetRoutineImplementation(InternalName, .tokens, $namespace))
+                do ..JSONLint(.tokens,routineDef.Code,.newTokens)
                 do routineDef.Code.Rewind()
             }
 
@@ -548,6 +550,177 @@ ClassMethod IndentDocument(InternalName As %String) As %Status
         write !, "Encountered "_$length($system.Status.GetErrorCodes(status), ",")_ " errors during indentation in "_duration_"."
     }
     quit status
+}
+
+ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTokens)
+{
+    kill newTokens
+    set isJSON = 0
+    set oneDimArray = 1
+
+    //Vertical Spacing for JSON Array
+    for line=1:1:$Get(tokens,0) {
+        set lineTokens = tokens(line)
+        set pointer = 0
+        set newLineTokens = ""
+        while $listnext(lineTokens,pointer,token) {
+            set $ListBuild(lang, type, fragment) = token
+            set newLineTokens = newLineTokens _ $ListBuild(token)
+
+            // Handle special rules for line breaks/removing white space
+            // for JSON brackets and delimiters. 
+            if (lang = "COS") && (type = "JSON bracket") {
+                // For {, enforce line break
+                // For }, enforce , or ] after, then line break
+                // For [, enforce { after, then line break
+                // Additionally, if next line starts with { or }, enforce line break
+                if (fragment = "{") {
+                    set pointerCopy = pointer
+                    if $listnext(lineTokens,pointerCopy,dummy) {
+                        set newTokens($i(newTokens)) = newLineTokens
+                        set newLineTokens = ""
+                    }
+                } elseif (fragment = "}") {
+                    set nextToken = ..NextNonWhitespaceToken(.tokens,line,lineTokens,pointer,.nextLine,.nextLineTokens,.nextPointer)
+                    set $ListBuild(nextLang, nextType, nextFragment) = nextToken
+                    if ((nextToken '= "") && ((nextFragment = "]") || (nextFragment = ","))) {
+                        do $i(isJSON,-1*((nextFragment = "]")))
+                        set newLineTokens = newLineTokens _ $ListBuild(nextToken)
+                        set line = nextLine
+                        set lineTokens = nextLineTokens
+                        set pointer = nextPointer
+                        set newTokens($i(newTokens)) = newLineTokens
+                        set newLineTokens = ""
+                    }
+                } elseif (fragment = "[") {
+                    set oneDimArray = 0
+                    do $i(isJSON)
+                    set nextToken = ..NextNonWhitespaceToken(.tokens,line,lineTokens,pointer,.nextLine,.nextLineTokens,.nextPointer)
+                    if nextToken = $ListBuild("COS","JSON bracket","{") {
+                        set newLineTokens = newLineTokens _ $ListBuild(nextToken)
+                        set line = nextLine
+                        set lineTokens = nextLineTokens
+                        set pointer = nextPointer
+                        set pointerCopy = pointer
+                        if $listnext(lineTokens,pointerCopy,dummy) {
+                            set newTokens($i(newTokens)) = newLineTokens
+                            set newLineTokens = ""
+                        }
+                    }
+                }
+            } elseif type '= "White Space"{
+                set nextToken = ..NextNonWhitespaceToken(.tokens,line,lineTokens,pointer,.nextLine,.nextLineTokens,.nextPointer)
+                set pointerCopy = pointer
+                if (($listnext(lineTokens, pointerCopy, dummy)) && ((nextToken = $ListBuild("COS","JSON bracket","}"))||(('oneDimArray)&&(nextToken = $ListBuild("COS","JSON bracket","{"))))) {
+                    break
+                    set newTokens($i(newTokens)) = newLineTokens
+                    set newLineTokens = ""
+                }
+            }
+        }
+        if ((newLineTokens '= "") || (isJSON = 0)) {
+            set newTokens($i(newTokens)) = newLineTokens
+        }
+        
+    }
+    //Horizontal Spacing for JSON Arrays
+    kill tokens
+    merge tokens = newTokens
+    kill newTokens
+    kill newLineTokens
+    set indents = 1
+    set isJSON = 0
+    for line=1:1:$Get(tokens,0) {
+        set lineTokens = tokens(line)
+        set pointer = 0
+        set incIndent = 0
+        set decIndent = 0
+        set newLineTokens = ""
+        while $listnext(lineTokens, pointer, token) {
+            set $ListBuild(lang, type, fragment) = token
+
+            // Number of opening [ determine how many closing ] are needed
+            // to exit the array and then be outside JSON
+            if token = $ListBuild("COS","JSON bracket","[") {
+                do $i(isJSON)
+            } elseif token = $ListBuild("COS","JSON bracket","]") {
+                do $i(isJSON,-1)
+            }
+
+            //Determine whether the next line should be indented by 1
+            //or if current line should be unindented by 1
+            if isJSON {
+                if (fragment = "{" || fragment = "[") {
+                    set incIndent = 1
+                } elseif (fragment = "}" || fragment = "]") {
+                    set decIndent = 1
+                }
+                if ((type '= "White Space") || (fragment = " ")) {
+                    set newLineTokens = newLineTokens _ $ListBuild(token)
+                }
+            } else {
+                set newLineTokens = newLineTokens _ $ListBuild(token)
+            }
+        }
+
+        //Apply indentation and increase or decrease for next or current line
+        set indentChar = ##class(pkg.isc.codetidy.Utils).GetIndentString()
+        if newLineTokens '= "" {
+            if (isJSON && incIndent) {
+                for indent=1:1:indents {
+                    set newLineTokens = $ListBuild($ListBuild("COS","White Space",indentChar)) _ newLineTokens
+                }
+                do $i(indents)
+            } elseif (isJSON && decIndent) {
+                do $i(indents,-1)
+                for indent=1:1:indents {
+                    set newLineTokens = $ListBuild($ListBuild("COS","White Space",indentChar)) _ newLineTokens
+                }
+            } else {
+                for indent=1:1:indents {
+                    set newLineTokens = $ListBuild($ListBuild("COS","White Space",indentChar)) _ newLineTokens
+                }
+            }
+        }
+
+        //Ignore blank lines if in JSON array
+        if ((newLineTokens '= "") || (isJSON = 0)) {
+            set newTokens($i(newTokens)) = newLineTokens
+        }
+        
+        
+    }
+    
+    // Update source stream
+    do sourceStream.Clear()
+    for i=1:1:$Get(newTokens,0) {
+        set lineTokens = newTokens(i)
+        set pointer = 0
+        while $listnext(lineTokens,pointer,token) {
+            do sourceStream.Write($ListGet(token,3))
+        }
+        do sourceStream.WriteLine()
+    }
+}
+
+ClassMethod NextNonWhitespaceToken(ByRef tokens, line As %Integer, lineTokens As %List, pointer As %Integer, Output newLine, Output newLineTokens, Output newPointer) As %List
+{
+    // Parse through tokens to find next non-whitespace token,
+    // returning the token and getting the new pointer and line number
+    set newLine = line, newLineTokens = lineTokens, newPointer = pointer
+    for {
+        while $ListNext(newLineTokens,newPointer,newToken) {
+            set $listbuild(lang,type,fragment) = newToken
+            if (type '= "White Space") {
+                return newToken
+            }
+        }
+        set newLine = newLine + 1
+        if '$data(tokens(newLine),newLineTokens)#2 {
+            return ""
+        }
+        set newPointer = 0
+    }
 }
 
 /// Apply standard indentation to a given line of code.
@@ -685,11 +858,12 @@ ClassMethod DecIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
         set openTags(3) = "&javascript<"
         set openTags(4) = "&html<"
         set openTags(5) = "/*"
-        if IsJSON {
-            set openTags(6) = "["
-            set openTags = $increment(openTags)
+        /*if IsJSON {
+			// disabled to debug json bracket handling
+			set openTags(6) = "["
+			set openTags = $increment(openTags)
         }
-
+        */
         // if previously in = indent and new command shows up decrease indent
         // also decrease indent for comments
         if $get(Handle("decOnNextCommand")) &&
@@ -915,7 +1089,7 @@ ClassMethod IncIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
         set openTags(3) = "&javascript<"
         set openTags(4) = "&html<"
         set openTags(5) = "/*"
-        if IsJSON {
+        /*if IsJSON {
             set openTags(6) = "["
             set openTags = $increment(openTags)
 
@@ -934,7 +1108,7 @@ ClassMethod IncIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
                 set Handle("indentedJSON") = 1
             }
         }
-
+        */
         // Check for = or _ at the end of the line and indent next line
         set lastChar = $extract(LineText, $length(LineText))
         if ('IsJSON) && (command '= "") && ((lastChar = "=") || (lastChar = "_")) && ('$get(Handle("decOnNextCommand"))) {
@@ -1859,4 +2033,3 @@ Method OnAfterSave(InternalName As %String, Object As %RegisteredObject = {$$$NU
 }
 
 }
-

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -556,9 +556,11 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
 {
     kill newTokens
     set isJSON = 0
+
+    #; Special case detection of 1-D array in curly braces
     set oneDimArray = 1
 
-    //Vertical Spacing for JSON Array
+    #; Vertical Spacing for JSON Array
     for line=1:1:$Get(tokens,0) {
         set lineTokens = tokens(line)
         set pointer = 0
@@ -567,13 +569,15 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
             set $ListBuild(lang, type, fragment) = token
             set newLineTokens = newLineTokens _ $ListBuild(token)
 
-            // Handle special rules for line breaks/removing white space
-            // for JSON brackets and delimiters. 
+            #; Handle special rules for line breaks/removing white space
+            #; for JSON brackets and delimiters. 
+
+            #; Rules:
+            #; For {, enforce line break
+            #; For }, enforce , or ] after, then line break
+            #; For [, enforce { after, then line break
+            #; Additionally, if next line starts with { or }, enforce line break
             if (lang = "COS") && (type = "JSON bracket") {
-                // For {, enforce line break
-                // For }, enforce , or ] after, then line break
-                // For [, enforce { after, then line break
-                // Additionally, if next line starts with { or }, enforce line break
                 if (fragment = "{") {
                     set pointerCopy = pointer
                     if $listnext(lineTokens,pointerCopy,dummy) {
@@ -612,7 +616,6 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
                 set nextToken = ..NextNonWhitespaceToken(.tokens,line,lineTokens,pointer,.nextLine,.nextLineTokens,.nextPointer)
                 set pointerCopy = pointer
                 if (($listnext(lineTokens, pointerCopy, dummy)) && ((nextToken = $ListBuild("COS","JSON bracket","}"))||(('oneDimArray)&&(nextToken = $ListBuild("COS","JSON bracket","{"))))) {
-                    break
                     set newTokens($i(newTokens)) = newLineTokens
                     set newLineTokens = ""
                 }
@@ -623,13 +626,15 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
         }
         
     }
-    //Horizontal Spacing for JSON Arrays
+
+    #; Horizontal Spacing for JSON Arrays
     kill tokens
     merge tokens = newTokens
     kill newTokens
     kill newLineTokens
     set indents = 1
     set isJSON = 0
+
     for line=1:1:$Get(tokens,0) {
         set lineTokens = tokens(line)
         set pointer = 0
@@ -639,16 +644,16 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
         while $listnext(lineTokens, pointer, token) {
             set $ListBuild(lang, type, fragment) = token
 
-            // Number of opening [ determine how many closing ] are needed
-            // to exit the array and then be outside JSON
+            #; Number of opening [ determine how many closing ] are needed
+            #; to exit the array and then be outside JSON
             if token = $ListBuild("COS","JSON bracket","[") {
                 do $i(isJSON)
             } elseif token = $ListBuild("COS","JSON bracket","]") {
                 do $i(isJSON,-1)
             }
 
-            //Determine whether the next line should be indented by 1
-            //or if current line should be unindented by 1
+            #; Determine whether the next line should be indented by 1
+            #; or if current line should be unindented by 1
             if isJSON {
                 if (fragment = "{" || fragment = "[") {
                     set incIndent = 1
@@ -663,7 +668,7 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
             }
         }
 
-        //Apply indentation and increase or decrease for next or current line
+        #; Apply indentation and increase or decrease for next or current line
         set indentChar = ##class(pkg.isc.codetidy.Utils).GetIndentString()
         if newLineTokens '= "" {
             if (isJSON && incIndent) {
@@ -683,7 +688,7 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
             }
         }
 
-        //Ignore blank lines if in JSON array
+        #; Ignore blank lines if in JSON array
         if ((newLineTokens '= "") || (isJSON = 0)) {
             set newTokens($i(newTokens)) = newLineTokens
         }
@@ -705,8 +710,8 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
 
 ClassMethod NextNonWhitespaceToken(ByRef tokens, line As %Integer, lineTokens As %List, pointer As %Integer, Output newLine, Output newLineTokens, Output newPointer) As %List
 {
-    // Parse through tokens to find next non-whitespace token,
-    // returning the token and getting the new pointer and line number
+    #; Parse through tokens to find next non-whitespace token,
+    #; returning the token and getting the new pointer and line number
     set newLine = line, newLineTokens = lineTokens, newPointer = pointer
     for {
         while $ListNext(newLineTokens,newPointer,newToken) {

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -863,12 +863,7 @@ ClassMethod DecIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
         set openTags(3) = "&javascript<"
         set openTags(4) = "&html<"
         set openTags(5) = "/*"
-        /*if IsJSON {
-			// disabled to debug json bracket handling
-			set openTags(6) = "["
-			set openTags = $increment(openTags)
-        }
-        */
+    
         // if previously in = indent and new command shows up decrease indent
         // also decrease indent for comments
         if $get(Handle("decOnNextCommand")) &&
@@ -1094,26 +1089,7 @@ ClassMethod IncIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
         set openTags(3) = "&javascript<"
         set openTags(4) = "&html<"
         set openTags(5) = "/*"
-        /*if IsJSON {
-            set openTags(6) = "["
-            set openTags = $increment(openTags)
-
-            if ($get(Handle("indentedJSON")) = 1) && ($extract(LineText, $length(LineText)) = ",") {
-                kill Handle("indentedJSON")
-                set incIndent = incIndent - 1
-            }
-
-            // Extra JSON rule: if ending with [{ in JSON, only indent once
-            if $extract(LineText, $length(LineText) - 1, *) = "[{" {
-                set incIndent = incIndent - 1
-            } elseif (LineText = "}]") {
-                set incIndent = $increment(incIndent)
-            } elseif ($extract(LineText, $length(LineText)) = ":") {
-                set incIndent = $increment(incIndent)
-                set Handle("indentedJSON") = 1
-            }
-        }
-        */
+        
         // Check for = or _ at the end of the line and indent next line
         set lastChar = $extract(LineText, $length(LineText))
         if ('IsJSON) && (command '= "") && ((lastChar = "=") || (lastChar = "_")) && ('$get(Handle("decOnNextCommand"))) {

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -864,16 +864,19 @@ ClassMethod DecIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
         // Set custom marker for embedded block if used
         if $extract(LineText, 1, 11) = "&javascript" {
             set marker = $piece($piece(LineText, "&javascript", 2), "<", 1)
+        } elseif $extract(LineText, 1, 3) = "&js" {
+            set marker = $piece($piece(LineText, "&js", 2), "<", 1)
         } elseif $extract(LineText, 1, 5) = "&html" {
             set marker = $piece($piece(LineText, "&html", 2), "<", 1)
         } 
 
-        set openTags = 5
+        set openTags = 6
         set openTags(1) = "{"
         set openTags(2) = "("
         set openTags(3) = "&javascript" _ marker _ "<"
-        set openTags(4) = "&html" _ marker _ "<"
-        set openTags(5) = "/*"
+        set openTags(4) = "&js" _ marker _ "<"
+        set openTags(5) = "&html" _ marker _ "<"
+        set openTags(6) = "/*"
     
         // if previously in = indent and new command shows up decrease indent
         // also decrease indent for comments
@@ -900,7 +903,7 @@ ClassMethod DecIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
             if (+$get(Handle(openParNoMarker))) > 0 {
                 set closeCount = $length(LineText, closePar) - $length(LineText, openPar)
                 set Handle(openParNoMarker) = Handle(openParNoMarker) - closeCount
-                if ((openParNoMarker = "&html<") || (openParNoMarker = "&javascript<")) && (+$get(Handle(openParNoMarker)) = 0) {
+                if ((openParNoMarker = "&html<") || (openParNoMarker = "&javascript<") || (openParNoMarker = "&js<")) && (+$get(Handle(openParNoMarker)) = 0) {
                     set marker = ""
                 }
                 // set Handle(openTags(tagIndex)) = Handle(openPar)
@@ -1097,16 +1100,19 @@ ClassMethod IncIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
         // Set custom marker for embedded block if used
         if $extract(LineText, 1, 11) = "&javascript" {
             set marker = $piece($piece(LineText, "&javascript", 2), "<", 1)
+        } elseif $extract(LineText, 1, 3) = "&js" {
+            set marker = $piece($piece(LineText, "&js", 2), "<", 1)
         } elseif $extract(LineText, 1, 5) = "&html" {
             set marker = $piece($piece(LineText, "&html", 2), "<", 1)
         }
 
-        set openTags = 5
+        set openTags = 6
         set openTags(1) = "{"
         set openTags(2) = "("
         set openTags(3) = "&javascript" _ marker _ "<"
-        set openTags(4) = "&html" _ marker _ "<"
-        set openTags(5) = "/*"
+        set openTags(4) = "&js" _ marker _ "<"
+        set openTags(5) = "&html" _ marker _ "<"
+        set openTags(6) = "/*"
         
         // Check for = or _ at the end of the line and indent next line
         set lastChar = $extract(LineText, $length(LineText))

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -307,10 +307,11 @@ ClassMethod IndentDocument(InternalName As %String) As %Status
                 set lineNumber = 1
                 set command = ""
                 set isJSON = 0
+                set marker = ""
                 for  {
                     kill len
                     set lineText = method.Implementation.ReadLine(.len)
-                    if len = -1  quit  //
+                    if len = -1  quit
                     
                     if (method.Language = $$$langObjectScript) || (method.Language = "") {
                         set command = ""
@@ -343,7 +344,9 @@ ClassMethod IndentDocument(InternalName As %String) As %Status
                         set lineNumber = $increment(lineNumber)
                     }
 
-                    do ..IndentCodeLine(.handle, $case(method.Language, "":$$$langObjectScript, :method.Language), .lineText, .indent, command, isJSON)
+                    if '$Get(handle("&html<")) {
+                        do ..IndentCodeLine(.handle, $case(method.Language, "":$$$langObjectScript, :method.Language), .lineText, .indent, command, isJSON, .marker)
+                    }
                     if 'method.Implementation.AtEnd {
                         do code.WriteLine(lineText)
                     } else {
@@ -474,7 +477,9 @@ ClassMethod IndentDocument(InternalName As %String) As %Status
                     set lineNumber = $increment(lineNumber)
                 }
                 
-                do ..IndentCodeLine(.handle, language, .lineText, .indent, command, isJSON)
+                if '$Get(Handle("&html<")) {
+                    do ..IndentCodeLine(.handle, language, .lineText, .indent, command, isJSON, .marker)
+                }
                 if 'routineDef.Code.AtEnd {
                     do code.WriteLine(lineText)
                 } else {
@@ -642,6 +647,14 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
 
     for line=1:1:$Get(tokens,0) {
         set lineTokens = tokens(line)
+
+        #; Disregard lines within embedded HTML, JavaScript, or comments
+        set $ListBuild(firstLang, firstType, firstFragment) = $ListGet(lineTokens, 1)
+        if (firstLang '= "COS") || (firstType = "Comment") {
+            set newTokens($i(newTokens)) = lineTokens
+            continue
+        }
+
         set pointer = 0
         set incIndent = 0
         set decIndent = 0
@@ -657,6 +670,14 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
                 do $i(isJSON,-1)
             }
 
+            #; Detect one dimensional array as special case
+            if (token = $ListBuild("COS", "JSON bracket", "{")) && ('isJSON) {
+                set isJSON = 1
+            }
+            if (token = $ListBuild("COS", "JSON bracket", "}")) && ('isJSON) {
+                set isJSON = 0
+            }
+
             #; Determine whether the next line should be indented by 1
             #; or if current line should be unindented by 1
             if isJSON {
@@ -665,7 +686,7 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
                 } elseif (fragment = "}" || fragment = "]") {
                     set decIndent = 1
                 }
-                if ((type '= "White Space") || (fragment = " ")) {
+                if type '= "White Space" {
                     set newLineTokens = newLineTokens _ $ListBuild(token)
                 }
             } else {
@@ -675,6 +696,7 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
 
         #; Apply indentation and increase or decrease for next or current line
         set indentChar = ##class(pkg.isc.codetidy.Utils).GetIndentString()
+        set $ListBuild(firstLang, firstType, firstFragment) = $ListGet(newLineTokens,1)
         if newLineTokens '= "" {
             if (isJSON && incIndent) {
                 for indent=1:1:indents {
@@ -686,7 +708,7 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, Output newTok
                 for indent=1:1:indents {
                     set newLineTokens = $ListBuild($ListBuild("COS","White Space",indentChar)) _ newLineTokens
                 }
-            } else {
+            } elseif firstType '= "White Space" {
                 for indent=1:1:indents {
                     set newLineTokens = $ListBuild($ListBuild("COS","White Space",indentChar)) _ newLineTokens
                 }
@@ -735,7 +757,7 @@ ClassMethod NextNonWhitespaceToken(ByRef tokens, line As %Integer, lineTokens As
 
 /// Apply standard indentation to a given line of code.
 /// Note: This method is called with each line in sequence.  The Handle is used to keep track of details that effect the indentation of subsequent lines.
-ClassMethod IndentCodeLine(ByRef Handle As %Library.Binary, Language As %String, ByRef LineText As %String, ByRef Indent As %Integer, Command As %String = "", IsJSON As %Boolean = 0)
+ClassMethod IndentCodeLine(ByRef Handle As %Library.Binary, Language As %String, ByRef LineText As %String, ByRef Indent As %Integer, Command As %String = "", IsJSON As %Boolean = 0, ByRef marker As %String = "")
 {
     #; Check for line label
     set leadChar = $extract(LineText, 1)
@@ -748,7 +770,7 @@ ClassMethod IndentCodeLine(ByRef Handle As %Library.Binary, Language As %String,
     set LineText = $zstrip(LineText,">W")
     
     #; Check whether this line should be moved out.
-    set decIndent = ..DecIndent(.Handle, (LineText), Language, Command, IsJSON)
+    set decIndent = ..DecIndent(.Handle, (LineText), Language, Command, IsJSON, .marker)
     
     set Indent = Indent - decIndent
     if Indent < 0 set Indent = 0
@@ -757,34 +779,11 @@ ClassMethod IndentCodeLine(ByRef Handle As %Library.Binary, Language As %String,
     set indentLength = $length(indentChar)
     
     #; Build new line.
-    set formatLine = ""
-    if (Language = $$$langObjectScript) || (Language = "") {
-        set formatLine = LineText
-        if '$get(Handle("&sql(")),'$get(Handle("&js<")),'$get(Handle("&html<")) {
-            // Forget indentation offset for any previous embedded section
-            kill Handle("IndentHTML")
-        } else {
-            // Preserve user indentation of embedded html blocks
-            if $get(Handle("&html<")) {
-                set numTabs = 0
-                while $extract(originalText, numTabs*indentLength + 1, numTabs*indentLength + indentLength) = indentChar {
-                    set numTabs = $increment(numTabs)
-                }
-                if ($get(Handle("IndentHTML")) = "") {
-                    set Handle("IndentHTML") = Indent - numTabs
-                } else {
-                    set Indent = numTabs + +$get(Handle("IndentHTML"))
-                }
-            }
-        }
-    } else {
-        #; Other languages don't use dot structures.
-        set formatLine = LineText
-    }
+    set formatLine = LineText
     
     if 'lineLabel {
         #; Check whether the next line should be moved in.
-        set incIndent = ..IncIndent(.Handle, LineText, Language, Command, IsJSON)
+        set incIndent = ..IncIndent(.Handle, LineText, Language, Command, IsJSON, .marker)
 
         // Preserve indentation of /**/ comments
         if (Language = $$$langObjectScript) || (Language = "") {
@@ -822,7 +821,7 @@ ClassMethod IndentCodeLine(ByRef Handle As %Library.Binary, Language As %String,
 
 /// Temporarily putting this method here
 /// it is a rewrite from the basic version to objectscript
-ClassMethod DecIndent(ByRef Handle As %Library.Binary, LineText As %String, Language As %String, ObjectScriptCommand As %String, IsJSON As %Boolean) As %Integer
+ClassMethod DecIndent(ByRef Handle As %Library.Binary, LineText As %String, Language As %String, ObjectScriptCommand As %String, IsJSON As %Boolean, ByRef marker As %String = "") As %Integer
 {
     // Decrease Indent
     #dim endOfCommand as %Integer
@@ -862,11 +861,18 @@ ClassMethod DecIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
             set decIndent = 0
         }
 
+        // Set custom marker for embedded block if used
+        if $extract(LineText, 1, 11) = "&javascript" {
+            set marker = $piece($piece(LineText, "&javascript", 2), "<", 1)
+        } elseif $extract(LineText, 1, 5) = "&html" {
+            set marker = $piece($piece(LineText, "&html", 2), "<", 1)
+        } 
+
         set openTags = 5
         set openTags(1) = "{"
         set openTags(2) = "("
-        set openTags(3) = "&javascript<"
-        set openTags(4) = "&html<"
+        set openTags(3) = "&javascript" _ marker _ "<"
+        set openTags(4) = "&html" _ marker _ "<"
         set openTags(5) = "/*"
     
         // if previously in = indent and new command shows up decrease indent
@@ -879,24 +885,24 @@ ClassMethod DecIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
         }
 
         for tagIndex = 1:1:openTags {
-            if $extract(openTags(tagIndex)) = "&" {
-                set openPar = "<"
-            } else {
-                set openPar = openTags(tagIndex)
-            }
+            set openPar = openTags(tagIndex)
             set closePar = $case(
                 openPar,
                 "{": "}",
                 "(": ")",
                 "/*": "*/",
                 "[": "]",
-                : ">"
+                : ">" _ $reverse(marker)
             )
 
             // check for block statements
-            if (+$get(Handle(openTags(tagIndex)))) > 0 {
+            set openParNoMarker = $replace(openPar, marker, "")
+            if (+$get(Handle(openParNoMarker))) > 0 {
                 set closeCount = $length(LineText, closePar) - $length(LineText, openPar)
-                set Handle(openPar) = Handle(openTags(tagIndex)) - closeCount
+                set Handle(openParNoMarker) = Handle(openParNoMarker) - closeCount
+                if ((openParNoMarker = "&html<") || (openParNoMarker = "&javascript<")) && (+$get(Handle(openParNoMarker)) = 0) {
+                    set marker = ""
+                }
                 // set Handle(openTags(tagIndex)) = Handle(openPar)
                 if closeCount > 0 {
                     if closePar '= "*/" {
@@ -1031,7 +1037,7 @@ ClassMethod DecIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
 
 /// Temporarily putting this method here
 /// it is a rewrite from the basic version to objectscript
-ClassMethod IncIndent(ByRef Handle As %Library.Binary, LineText As %String, Language As %String, ObjectScriptCommand As %String, IsJSON As %Boolean) As %Integer
+ClassMethod IncIndent(ByRef Handle As %Library.Binary, LineText As %String, Language As %String, ObjectScriptCommand As %String, IsJSON As %Boolean, ByRef marker As %String) As %Integer
 {
     #dim endOfCommand as %Integer
     #dim command as %String
@@ -1088,11 +1094,18 @@ ClassMethod IncIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
             set incIndent = 0
         }
 
+        // Set custom marker for embedded block if used
+        if $extract(LineText, 1, 11) = "&javascript" {
+            set marker = $piece($piece(LineText, "&javascript", 2), "<", 1)
+        } elseif $extract(LineText, 1, 5) = "&html" {
+            set marker = $piece($piece(LineText, "&html", 2), "<", 1)
+        }
+
         set openTags = 5
         set openTags(1) = "{"
         set openTags(2) = "("
-        set openTags(3) = "&javascript<"
-        set openTags(4) = "&html<"
+        set openTags(3) = "&javascript" _ marker _ "<"
+        set openTags(4) = "&html" _ marker _ "<"
         set openTags(5) = "/*"
         
         // Check for = or _ at the end of the line and indent next line
@@ -1112,13 +1125,14 @@ ClassMethod IncIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
                 "(": ")",
                 "/*": "*/",
                 "[": "]",
-                : ">"
+                : ">" _ $reverse(marker)
             )
 
             // Check for block statements
+            set openParNoMarker = $replace(openPar, marker, "")
             set openCount = $length(LineText, openPar) - $length(LineText, closePar)
             if openCount > 0 {
-                set Handle(openPar) = $get(Handle(openTags(tagIndex))) + openCount
+                set Handle(openParNoMarker) = $get(Handle(openParNoMarker)) + openCount
                 if openPar '= "/*" {
                     set incIndent = incIndent + openCount
                 }

--- a/cls/pkg/isc/codetidy/CodeTidy.cls
+++ b/cls/pkg/isc/codetidy/CodeTidy.cls
@@ -607,7 +607,6 @@ ClassMethod ParseFragmentCOS(ByRef last, ByRef this, ByRef next, ByRef conv)
 	// &javascript
 	if this("Type") = $$$COSJavascript {
 		set conv("Frag") = this("Frag")
-		if $zconvert(conv("Frag"), "L") = "js" set conv("Frag") = "javascript"
 		if ##class(pkg.isc.codetidy.Utils).GetUseCapitals() = 0 {
 			set conv("Frag") = $zconvert(conv("Frag"), "l")
 		} else {

--- a/cls/pkg/isc/codetidy/CodeTidy.cls
+++ b/cls/pkg/isc/codetidy/CodeTidy.cls
@@ -299,10 +299,12 @@ ClassMethod ParseLine(ByRef last, ByRef this, ByRef next, ByRef conv)
 		
 		if ..#DEBUG, $increment(%debug) < 1000 write this("Indent"), ":", next("Indent"), ":", multiLineCommand, ":", conv("Line"), !
 		
-		if ($extract(conv("Line")) = ##class(pkg.isc.codetidy.Utils).GetIndentString()) {
+		set indentString = ##class(pkg.isc.codetidy.Utils).GetIndentString()
+		set indented = ($extract(conv("Line"), 1, $length(indentString)) = indentString)
+		if (indented) && (last("Lang") '= "HTML") {
 			// Indentation
-			set conv("Frag") = ##class(pkg.isc.codetidy.Utils).GetIndentString() _ $translate($justify("", this("Indent") + multiLineCommand), $char(32), $char(9))
-			set conv("Line") = conv("Frag") _ $extract(conv("Line"), 2, *)
+			set conv("Frag") = indentString _ $replace($justify("", this("Indent") + multiLineCommand), $char(32), indentString)
+			set conv("Line") = conv("Frag") _ $extract(conv("Line"), 1+$length(indentString), *)
 		} else {
 			// Ignore indentation for ObjectScript line labels
 			// NOTE: Reference last language as "this" is the new line with no language.
@@ -335,6 +337,9 @@ ClassMethod InsertFragment(ByRef last, ByRef this)
 
 ClassMethod ReadFragment(ByRef last, ByRef this, ByRef next)
 {
+	set thisIsWhiteSpace = 0
+	set nextIsWhiteSpace = 0
+
 	set last("Lang") = this("Lang")
 	set last("Type") = this("Type")
 	set last("Frag") = this("Frag")
@@ -347,14 +352,36 @@ ClassMethod ReadFragment(ByRef last, ByRef this, ByRef next)
 	set this("Lang") = next("Lang")
 	set this("Type") = next("Type")
 	set this("Frag") = next("Frag")
+
+	// Prevent auto-indentation of embedded HTML
+	if (this("Type") = $$$HTMLWhiteSpace) && (this("Lang") = "HTML") {
+		set this("Type") = $$$HTMLText
+	}
 	
 	if 'this("SyntaxStream").AtEnd {
-		set nextLine = this("SyntaxStream").ReadLine()
-		set next("Lang") = $piece(nextLine, ",", 1)
-		set next("Type") = $piece(nextLine, ",", 2)
-		set next("Frag") = $piece(nextLine, ",", 3, *)
+		// Get next code fragment, combining white space characters
+		set mixedIndent = 1
+		while mixedIndent {
+			set nextLine = this("SyntaxStream").ReadLine()
+			set next("Lang") = $piece(nextLine, ",", 1)
+			set next("Type") = $piece(nextLine, ",", 2)
+			set next("Frag") = $piece(nextLine, ",", 3, *)
+
+			// Checks if "next" is a different white space character than "this" and combines
+			set thisIsWhiteSpace = ($extract(this("Frag")) = $c(9)) || ($extract(this("Frag")) = $c(32))
+			set nextIsWhiteSpace = ($extract(next("Frag")) = $c(9)) || ($extract(next("Frag")) = $c(32))
+			set mixedIndent = (thisIsWhiteSpace) && (nextIsWhiteSpace)
+			if mixedIndent {
+				set this("Frag") = this("Frag") _ next("Frag")
+			}
+		}
 	} else {
 		set this("AtEnd") = 1
+	}
+
+	// Resume auto-indentation at close of embedded block
+	if (($extract(this("Frag")) = $c(32)) || ($extract(this("Frag")) = $c(9))) && (next("Lang") [ "COS") && (next("Frag") = ">") {
+		set this("Type") = $$$HTMLWhiteSpace
 	}
 	
 	if ..#DEBUG, $data(nextLine) write nextLine, !
@@ -364,7 +391,7 @@ ClassMethod ParseFragment(ByRef last, ByRef this, ByRef next, ByRef conv)
 {
 	// Indentation
 	if $case(this("Lang"),
-		"COS":$case(this("Type"), $$$COSWhiteSpace:1, $$$COSComment:1, :0),
+		"COS":$case(this("Type"), $$$COSWhiteSpace:1, :0),
 		"CSS":$case(this("Type"), $$$CSSWhiteSpace:1, $$$CSSCstyleComment:1, :0),
 		"HTML":$case(this("Type"), $$$HTMLWhiteSpace:1, $$$HTMLComment:1, :0),
 		"JAVASCRIPT":$case(this("Type"), $$$JAVASCRIPTWhiteSpace:1, $$$JAVASCRIPTComment:1, :0),

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="IRIS" version="26">
 <Document name="isc.codetidy.ZPM"><Module>
   <Name>isc.codetidy</Name>
-  <Version>1.1.1</Version>
+  <Version>1.1.2</Version>
   <Packaging>module</Packaging>
   <Resource Name="pkg.isc.codetidy.PKG" Directory="cls" />
   <Resource Name="pkg.isc.codetidy.CodeTidy.INC" Directory="inc" />

--- a/tests/_reference/after/TestPackage.BlockCommentTestClass.cls
+++ b/tests/_reference/after/TestPackage.BlockCommentTestClass.cls
@@ -1,0 +1,29 @@
+Class TestPackage.BlockCommentTestClass
+{
+
+Method BlockCommentTest()
+{
+    /*
+        Do not change
+            my indentation
+        even if inconsistent
+            or containing "code"
+                set foo = "bar"
+            if (foo = "bar") {
+                do thing
+                }
+    */
+
+    set foo = "bar"
+
+    /* Or even if
+        there are
+            multiple blocks,
+        multiple openings /*
+    or misaligned closings
+                    within the block
+        */
+}
+
+}
+

--- a/tests/_reference/after/TestPackage.HTMLIndentTestClass.cls
+++ b/tests/_reference/after/TestPackage.HTMLIndentTestClass.cls
@@ -1,0 +1,83 @@
+Class TestPackage.HTMLIndentTestClass
+{
+
+Method HTMLGoodIndent()
+{
+    &html<
+            <html>
+                <head></head>
+                <body></body>
+    >
+}
+
+Method HTMLBlockIndent()
+{
+    &html<
+                <html>
+                    <head></head>
+                    <body></body>
+    >
+}
+
+Method HTMLBadIndent()
+{
+    &html<
+        <html>
+        <head>
+        </head>
+        <body>
+        </body>
+    >
+}
+
+Method HTMLIfBlock()
+{
+    if 1 {
+        &html<
+                <html>
+                    <head></head>
+                    <body></body>
+        >
+    }
+}
+
+Method HTMLUntidyIfBlock()
+{
+    if 1 {
+        if 1 {
+            &html<
+                        <html>
+                            <head></head>
+                            <body></body>
+            >
+        } else {
+            &html<
+                        <html>
+                        <head>
+                        </head>
+                        <body>
+                        </body>
+            >
+        }
+    }
+}
+
+Method HTMLOneLine()
+{
+    &html<<a href='url'>Link</a>>
+}
+
+Method HTMLMarker()
+{
+    &htmlabc<
+        <html>
+            <body>
+                4 > 3 
+                5>>7 >>>
+                4 > 2 >>
+            </body>
+    >cba
+}
+
+}
+

--- a/tests/_reference/after/TestPackage.JSIndentTestClass.cls
+++ b/tests/_reference/after/TestPackage.JSIndentTestClass.cls
@@ -83,5 +83,28 @@ Method JavaScriptMarker()
     >321
 }
 
+Method JavaScriptAbbrev()
+{
+    if 1 {
+        &js<
+            function foo(bar)
+            {
+                return true
+            }
+
+
+        >
+    }
+
+    &jsabc<
+        function foo(bar)
+        {
+            if (6 > 5) {
+                return True
+            }
+        }
+    >cba
+}
+
 }
 

--- a/tests/_reference/after/TestPackage.JSIndentTestClass.cls
+++ b/tests/_reference/after/TestPackage.JSIndentTestClass.cls
@@ -1,0 +1,87 @@
+Class TestPackage.JSIndentTestClass
+{
+
+Method JavaScriptTidy()
+{
+    &javascript<
+        function foo(bar)
+        {
+            // This is a comment
+            return true
+        }
+    >
+}
+
+Method JavaScriptUnindent()
+{
+    &javascript<
+        function foo(bar)
+        {
+            // This is a comment
+            return true
+        }
+    >
+}
+
+Method JavaScriptNeedsIndent()
+{
+    &javascript<
+        function foo(bar)
+        {
+            // This is a comment
+            return true
+        }
+    >
+}
+
+Method JavaScriptTwoBlocks()
+{
+    &javascript<
+        function foo(bar)
+        {
+            // This is a comment
+            return true
+        }
+    >
+    &javascript<
+        function foo(bar)
+        {
+            // This is a comment
+            return true
+        }
+    >
+}
+
+Method JavaScriptOneLine()
+{
+    &javascript<function foo(bar) {return true}>
+}
+
+Method JavaScriptVeryMessy()
+{
+    if 1 {
+        &javascript<
+            function foo(bar)
+            {
+                return true
+            }
+
+
+        >
+    }
+}
+
+Method JavaScriptMarker()
+{
+    &javascript123<
+        function foo(bar)
+        {
+            if (6 > 5) {
+                return True
+            }
+        }
+    >321
+}
+
+}
+

--- a/tests/_reference/after/TestPackage.JSONBracketMatching.cls
+++ b/tests/_reference/after/TestPackage.JSONBracketMatching.cls
@@ -1,0 +1,15 @@
+Class TestPackage.JSONBracketMatching
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+    set example = [{
+        "foo":"bar"
+    },
+    {
+        "bar":"foo"
+    }]
+}
+
+}
+

--- a/tests/_reference/after/TestPackage.JSONBracketMixed.cls
+++ b/tests/_reference/after/TestPackage.JSONBracketMixed.cls
@@ -1,0 +1,15 @@
+Class TestPackage.JSONBracketMixed
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+    set example = [{
+        "foo":"bar"
+    },
+    {
+        "bar":"foo"
+    }]
+}
+
+}
+

--- a/tests/_reference/after/TestPackage.JSONBracketOneLine.cls
+++ b/tests/_reference/after/TestPackage.JSONBracketOneLine.cls
@@ -1,0 +1,15 @@
+Class TestPackage.JSONBracketOneLine
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+    set example = [{
+        "foo":"bar"
+    },
+    {
+        "bar":"foo"
+    }]
+}
+
+}
+

--- a/tests/_reference/after/TestPackage.JSONIndent.cls
+++ b/tests/_reference/after/TestPackage.JSONIndent.cls
@@ -1,0 +1,15 @@
+Class TestPackage.JSONIndent
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+    set example = [{
+        "foo":"bar"
+    },
+    {
+        "bar":"foo"
+    }]
+}
+
+}
+

--- a/tests/_reference/after/TestPackage.JSONOneDimArray.cls
+++ b/tests/_reference/after/TestPackage.JSONOneDimArray.cls
@@ -1,0 +1,13 @@
+Class TestPackage.JSONOneDimArray
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+    set square = ["test"]
+    set curly = {
+        "foo":"bar"
+    }
+}
+
+}
+

--- a/tests/_reference/before/TestPackage.BlockCommentTestClass.cls
+++ b/tests/_reference/before/TestPackage.BlockCommentTestClass.cls
@@ -1,0 +1,28 @@
+Class TestPackage.BlockCommentTestClass
+{
+
+Method BlockCommentTest()
+{
+    /*
+        Do not change
+            my indentation
+        even if inconsistent
+            or containing "code"
+                set foo = "bar"
+            if (foo = "bar") {
+                do thing
+                }
+    */
+
+    set foo = "bar"
+
+    /* Or even if
+        there are 
+            multiple blocks,
+        multiple openings /* 
+    or misaligned closings
+                    within the block
+        */
+}
+
+}

--- a/tests/_reference/before/TestPackage.HTMLIndentTestClass.cls
+++ b/tests/_reference/before/TestPackage.HTMLIndentTestClass.cls
@@ -1,0 +1,82 @@
+Class TestPackage.HTMLIndentTestClass
+{
+
+Method HTMLGoodIndent()
+{
+    &html<
+            <html>
+                <head></head>
+                <body></body>
+    >
+}
+
+Method HTMLBlockIndent()
+{
+        &html<
+                <html>
+                    <head></head>
+                    <body></body>
+        >
+}
+
+Method HTMLBadIndent()
+{
+    &html<
+        <html>
+        <head>
+        </head>
+        <body>
+        </body>
+        >
+}
+
+Method HTMLIfBlock()
+{
+    if 1 {
+            &html<
+                <html>
+                    <head></head>
+                    <body></body>
+        >
+    }
+}
+
+Method HTMLUntidyIfBlock()
+{
+    if 1 {
+            if 1{
+                &html<
+                        <html>
+                            <head></head>
+                            <body></body>
+                >
+            } else {
+                        &html<
+                        <html>
+                        <head>
+                        </head>
+                        <body>
+                        </body>
+                    >
+                }
+    }
+}
+
+Method HTMLOneLine()
+{
+    &html<<a href='url'>Link</a>>
+}
+
+Method HTMLMarker()
+{
+        &htmlabc<
+        <html>
+            <body>
+                4 > 3 
+                5>>7 >>>
+                4 > 2 >>
+            </body>
+            >cba
+}
+
+}

--- a/tests/_reference/before/TestPackage.JSIndentTestClass.cls
+++ b/tests/_reference/before/TestPackage.JSIndentTestClass.cls
@@ -1,0 +1,87 @@
+Class TestPackage.JSIndentTestClass
+{
+
+Method JavaScriptTidy()
+{
+    &javascript<
+        function foo(bar) 
+        {
+            // This is a comment
+            return true
+        }
+    >
+}
+
+Method JavaScriptUnindent()
+{
+        &javascript<
+                function foo(bar)
+                {
+                    // This is a comment
+                    return true
+                    }
+            >
+}
+
+Method JavaScriptNeedsIndent()
+{
+    &javascript<
+    function foo(bar)
+    {
+    // This is a comment
+    return true
+    }
+    >
+}
+
+Method JavaScriptTwoBlocks()
+{
+    &javascript<
+    function foo(bar)
+    {
+    // This is a comment
+    return true
+    }
+    >
+        &javascript<
+                function foo(bar)
+                {
+                    // This is a comment
+                    return true
+                    }
+                >
+}
+
+Method JavaScriptOneLine()
+{
+    &javascript<function foo(bar) {return true}>
+}
+
+Method JavaScriptVeryMessy()
+{
+    if 1 {
+    &javascript<
+                function foo(bar)
+            {
+                    return true
+                        }
+
+
+
+                    >
+        }
+}
+
+Method JavaScriptMarker()
+{
+    &javascript123<
+            function foo(bar)
+    {
+                if (6 > 5) {
+                        return True
+                        }
+                }
+        >321
+}
+
+}

--- a/tests/_reference/before/TestPackage.JSIndentTestClass.cls
+++ b/tests/_reference/before/TestPackage.JSIndentTestClass.cls
@@ -84,4 +84,28 @@ Method JavaScriptMarker()
         >321
 }
 
+Method JavaScriptAbbrev()
+{
+    if 1 {
+    &js<
+                function foo(bar)
+            {
+                    return true
+                        }
+
+
+
+                    >
+        }
+
+    &jsabc<
+            function foo(bar)
+    {
+                if (6 > 5) {
+                        return True
+                        }
+                }
+        >cba
+}
+
 }

--- a/tests/_reference/before/TestPackage.JSONBracketMatching.cls
+++ b/tests/_reference/before/TestPackage.JSONBracketMatching.cls
@@ -1,0 +1,15 @@
+Class TestPackage.JSONBracketMatching
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+	set example = [{
+		"foo":"bar"
+	},
+	{
+		"bar":"foo"
+	}
+	]
+}
+
+}

--- a/tests/_reference/before/TestPackage.JSONBracketMixed.cls
+++ b/tests/_reference/before/TestPackage.JSONBracketMixed.cls
@@ -1,0 +1,14 @@
+Class TestPackage.JSONBracketMixed
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+    set example = [{"foo":"bar"}
+        ,
+        {
+        "bar":"foo"
+    }
+        ]
+}
+
+}

--- a/tests/_reference/before/TestPackage.JSONBracketOneLine.cls
+++ b/tests/_reference/before/TestPackage.JSONBracketOneLine.cls
@@ -1,0 +1,9 @@
+Class TestPackage.JSONBracketOneLine
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+	set example = [{"foo":"bar"},{"bar":"foo"}]
+}
+
+}

--- a/tests/_reference/before/TestPackage.JSONIndent.cls
+++ b/tests/_reference/before/TestPackage.JSONIndent.cls
@@ -1,0 +1,14 @@
+Class TestPackage.JSONIndent
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+	set example = [{
+		            "foo":"bar"
+	},
+	    {
+		        "bar":"foo"
+	        }]
+}
+
+}

--- a/tests/_reference/before/TestPackage.JSONOneDimArray.cls
+++ b/tests/_reference/before/TestPackage.JSONOneDimArray.cls
@@ -1,0 +1,10 @@
+Class TestPackage.JSONOneDimArray
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+	set square = ["test"]
+	set curly = {"foo":"bar"}
+}
+
+}

--- a/tests/_reference/compare/TestPackage.BlockCommentTestClass.cls
+++ b/tests/_reference/compare/TestPackage.BlockCommentTestClass.cls
@@ -1,0 +1,29 @@
+Class TestPackage.BlockCommentTestClass
+{
+
+Method BlockCommentTest()
+{
+    /*
+        Do not change
+            my indentation
+        even if inconsistent
+            or containing "code"
+                set foo = "bar"
+            if (foo = "bar") {
+                do thing
+                }
+    */
+
+    set foo = "bar"
+
+    /* Or even if
+        there are
+            multiple blocks,
+        multiple openings /*
+    or misaligned closings
+                    within the block
+        */
+}
+
+}
+

--- a/tests/_reference/compare/TestPackage.HTMLIndentTestClass.cls
+++ b/tests/_reference/compare/TestPackage.HTMLIndentTestClass.cls
@@ -1,0 +1,83 @@
+Class TestPackage.HTMLIndentTestClass
+{
+
+Method HTMLGoodIndent()
+{
+    &html<
+            <html>
+                <head></head>
+                <body></body>
+    >
+}
+
+Method HTMLBlockIndent()
+{
+    &html<
+                <html>
+                    <head></head>
+                    <body></body>
+    >
+}
+
+Method HTMLBadIndent()
+{
+    &html<
+        <html>
+        <head>
+        </head>
+        <body>
+        </body>
+    >
+}
+
+Method HTMLIfBlock()
+{
+    if 1 {
+        &html<
+                <html>
+                    <head></head>
+                    <body></body>
+        >
+    }
+}
+
+Method HTMLUntidyIfBlock()
+{
+    if 1 {
+        if 1 {
+            &html<
+                        <html>
+                            <head></head>
+                            <body></body>
+            >
+        } else {
+            &html<
+                        <html>
+                        <head>
+                        </head>
+                        <body>
+                        </body>
+            >
+        }
+    }
+}
+
+Method HTMLOneLine()
+{
+    &html<<a href='url'>Link</a>>
+}
+
+Method HTMLMarker()
+{
+    &htmlabc<
+        <html>
+            <body>
+                4 > 3 
+                5>>7 >>>
+                4 > 2 >>
+            </body>
+    >cba
+}
+
+}
+

--- a/tests/_reference/compare/TestPackage.JSIndentTestClass.cls
+++ b/tests/_reference/compare/TestPackage.JSIndentTestClass.cls
@@ -83,5 +83,28 @@ Method JavaScriptMarker()
     >321
 }
 
+Method JavaScriptAbbrev()
+{
+    if 1 {
+        &js<
+            function foo(bar)
+            {
+                return true
+            }
+
+
+        >
+    }
+
+    &jsabc<
+        function foo(bar)
+        {
+            if (6 > 5) {
+                return True
+            }
+        }
+    >cba
+}
+
 }
 

--- a/tests/_reference/compare/TestPackage.JSIndentTestClass.cls
+++ b/tests/_reference/compare/TestPackage.JSIndentTestClass.cls
@@ -1,0 +1,87 @@
+Class TestPackage.JSIndentTestClass
+{
+
+Method JavaScriptTidy()
+{
+    &javascript<
+        function foo(bar)
+        {
+            // This is a comment
+            return true
+        }
+    >
+}
+
+Method JavaScriptUnindent()
+{
+    &javascript<
+        function foo(bar)
+        {
+            // This is a comment
+            return true
+        }
+    >
+}
+
+Method JavaScriptNeedsIndent()
+{
+    &javascript<
+        function foo(bar)
+        {
+            // This is a comment
+            return true
+        }
+    >
+}
+
+Method JavaScriptTwoBlocks()
+{
+    &javascript<
+        function foo(bar)
+        {
+            // This is a comment
+            return true
+        }
+    >
+    &javascript<
+        function foo(bar)
+        {
+            // This is a comment
+            return true
+        }
+    >
+}
+
+Method JavaScriptOneLine()
+{
+    &javascript<function foo(bar) {return true}>
+}
+
+Method JavaScriptVeryMessy()
+{
+    if 1 {
+        &javascript<
+            function foo(bar)
+            {
+                return true
+            }
+
+
+        >
+    }
+}
+
+Method JavaScriptMarker()
+{
+    &javascript123<
+        function foo(bar)
+        {
+            if (6 > 5) {
+                return True
+            }
+        }
+    >321
+}
+
+}
+

--- a/tests/_reference/compare/TestPackage.JSONBracketMatching.cls
+++ b/tests/_reference/compare/TestPackage.JSONBracketMatching.cls
@@ -1,0 +1,15 @@
+Class TestPackage.JSONBracketMatching
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+    set example = [{
+        "foo":"bar"
+    },
+    {
+        "bar":"foo"
+    }]
+}
+
+}
+

--- a/tests/_reference/compare/TestPackage.JSONBracketMixed.cls
+++ b/tests/_reference/compare/TestPackage.JSONBracketMixed.cls
@@ -1,0 +1,15 @@
+Class TestPackage.JSONBracketMixed
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+    set example = [{
+        "foo":"bar"
+    },
+    {
+        "bar":"foo"
+    }]
+}
+
+}
+

--- a/tests/_reference/compare/TestPackage.JSONBracketOneLine.cls
+++ b/tests/_reference/compare/TestPackage.JSONBracketOneLine.cls
@@ -1,0 +1,15 @@
+Class TestPackage.JSONBracketOneLine
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+    set example = [{
+        "foo":"bar"
+    },
+    {
+        "bar":"foo"
+    }]
+}
+
+}
+

--- a/tests/_reference/compare/TestPackage.JSONIndent.cls
+++ b/tests/_reference/compare/TestPackage.JSONIndent.cls
@@ -1,0 +1,15 @@
+Class TestPackage.JSONIndent
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+    set example = [{
+        "foo":"bar"
+    },
+    {
+        "bar":"foo"
+    }]
+}
+
+}
+

--- a/tests/_reference/compare/TestPackage.JSONOneDimArray.cls
+++ b/tests/_reference/compare/TestPackage.JSONOneDimArray.cls
@@ -1,0 +1,13 @@
+Class TestPackage.JSONOneDimArray
+{
+
+ClassMethod TestJSONArray() As %Status
+{
+    set square = ["test"]
+    set curly = {
+        "foo":"bar"
+    }
+}
+
+}
+

--- a/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
+++ b/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
@@ -9,509 +9,608 @@ Property deleteFiles As %Boolean [ InitialExpression = 0 ];
 
 Method OnBeforeAllTests() As %Status
 {
-    set ..userSourceControl = ##class(%Studio.SourceControl.Interface).SourceControlClassGet()
-    do ##class(%Studio.SourceControl.Interface).SourceControlClassSet("")
-    do ##class(pkg.isc.codetidy.Utils).SetupExtension()
-    merge ..userConfig = ^Config("CodeTidy")
+	set ..userSourceControl = ##class(%Studio.SourceControl.Interface).SourceControlClassGet()
+	do ##class(%Studio.SourceControl.Interface).SourceControlClassSet("")
+	do ##class(pkg.isc.codetidy.Utils).SetupExtension()
+	merge ..userConfig = ^Config("CodeTidy")
 
-    set ^Config("CodeTidy","brace")=1
-    set ^Config("CodeTidy","capital")=0
-    set ^Config("CodeTidy","codetidy")=1
-    set ^Config("CodeTidy","coscomment")="//"
-    set ^Config("CodeTidy","coswhitespace")=1
-    set ^Config("CodeTidy","eslintenabled")=0
-    set ^Config("CodeTidy","formatonsave")=0
-    set ^Config("CodeTidy","indent")=1
-    set ^Config("CodeTidy","indentString")="    "
-    set ^Config("CodeTidy","resequence")=0
-    set ^Config("CodeTidy","sqlcase")="U"
-    set ^Config("CodeTidy","sqlplan")=1
-    set ^Config("CodeTidy","tweak")="auto"
-    set ^Config("CodeTidy","usemacrocomments")=0
+	set ^Config("CodeTidy", "brace") = 1
+	set ^Config("CodeTidy", "capital") = 0
+	set ^Config("CodeTidy", "codetidy") = 1
+	set ^Config("CodeTidy", "coscomment") = "//"
+	set ^Config("CodeTidy", "coswhitespace") = 1
+	set ^Config("CodeTidy", "eslintenabled") = 0
+	set ^Config("CodeTidy", "formatonsave") = 0
+	set ^Config("CodeTidy", "indent") = 1
+	set ^Config("CodeTidy", "indentString") = "    "
+	set ^Config("CodeTidy", "resequence") = 0
+	set ^Config("CodeTidy", "sqlcase") = "U"
+	set ^Config("CodeTidy", "sqlplan") = 1
+	set ^Config("CodeTidy", "tweak") = "auto"
+	set ^Config("CodeTidy", "usemacrocomments") = 0
 
-    quit $$$OK
+	quit $$$OK
 }
 
 Method TestResequenceOptions()
 {
-    Set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir_"/../../../../_reference")
-    set referenceClassItemName = "TestPackage.ResequenceTestClass.cls"
-    set referenceClassName = referenceRoot_"before/"_referenceClassItemName
-    
-    // Run CodeTidy with resequencing enabled
-    set ^Config("CodeTidy","resequence") = 1
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-    
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.ResequenceTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	// Run CodeTidy with resequencing enabled
+	set ^Config("CodeTidy", "resequence") = 1
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.ResequenceTestClassEnabled.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
+	set resultClass = "TestPackage.ResequenceTestClassEnabled.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-    set currentDir = ..Manager.CurrentDir
-    zw currentDir,referenceRoot,exportFile
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
 
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
-    
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+	
 
-    // Run CodeTidy with resequencing disabled
-    set ^Config("CodeTidy","resequence") = 0
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
+	// Run CodeTidy with resequencing disabled
+	set ^Config("CodeTidy", "resequence") = 0
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.ResequenceTestClassDisabled.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	set resultClass = "TestPackage.ResequenceTestClassDisabled.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 }
 
 Method TestIndentationOptions()
 {
-    Set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir_"/../../../../_reference")
-    set referenceClassItemName = "TestPackage.IndentationTestClass.cls"
-    set referenceClassName = referenceRoot_"before/"_referenceClassItemName
-    
-    
-    // Run CodeTidy with automatic indentation set to 4 spaces
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-    
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.IndentationTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	
+	// Run CodeTidy with automatic indentation set to 4 spaces
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.IndentationTestClassSpaces.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	set resultClass = "TestPackage.IndentationTestClassSpaces.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 
-    // Run CodeTidy with automatic indentation set to tabs
-    set ^Config("CodeTidy","indentString") = $c(9)
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
+	// Run CodeTidy with automatic indentation set to tabs
+	set ^Config("CodeTidy", "indentString") = $char(9)
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.IndentationTestClassTabs.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	set resultClass = "TestPackage.IndentationTestClassTabs.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 
 
-    // Run CodeTidy with automatic indentation disabled
-    set ^Config("CodeTidy","indent") = 0 
-    set ^Config("CodeTidy","indentString") = ""
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
+	// Run CodeTidy with automatic indentation disabled
+	set ^Config("CodeTidy", "indent") = 0
+	set ^Config("CodeTidy", "indentString") = ""
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
-    Set truthFile = referenceRoot_"after/"_referenceClassItemName
-    Set exportFile = referenceRoot_"compare/"_referenceClassItemName
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	set truthFile = referenceRoot _ "after/" _ referenceClassItemName
+	set exportFile = referenceRoot _ "compare/" _ referenceClassItemName
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 
-    set ^Config("CodeTidy","indent") = 1 
-    set ^Config("CodeTidy","indentString") = "    "
+	set ^Config("CodeTidy", "indent") = 1
+	set ^Config("CodeTidy", "indentString") = "    "
 }
 
 Method TestAutoTweakOptions()
 {
-    Set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir_"/../../../../_reference")
-    set referenceClassItemName = "TestPackage.AutoTweakTestClass.cls"
-    set referenceClassName = referenceRoot_"before/"_referenceClassItemName
-    
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.AutoTweakTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
 
-    // Run CodeTidy with auto-tweak enabled
-    set ^Config("CodeTidy","tweak") = "auto"
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-    
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	// Run CodeTidy with auto-tweak enabled
+	set ^Config("CodeTidy", "tweak") = "auto"
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.AutoTweakTestClassEnabled.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
-    
+	set resultClass = "TestPackage.AutoTweakTestClassEnabled.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+	
 
-    // Run CodeTidy with auto-tweak disabled
-    set ^Config("CodeTidy","tweak") = ""
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
+	// Run CodeTidy with auto-tweak disabled
+	set ^Config("CodeTidy", "tweak") = ""
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.AutoTweakTestClassDisabled.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	set resultClass = "TestPackage.AutoTweakTestClassDisabled.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 }
 
 Method TestExpansionOptions()
 {
-    Set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir_"/../../../../_reference")
-    set referenceClassItemName = "TestPackage.ExpansionTestClass.cls"
-    set referenceClassName = referenceRoot_"before/"_referenceClassItemName
-    
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.ExpansionTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
 
-    // Run CodeTidy with lower-case expansion
-    set ^Config("CodeTidy","capital")=0
-    set ^Config("CodeTidy","codetidy")=1
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-    
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	// Run CodeTidy with lower-case expansion
+	set ^Config("CodeTidy", "capital") = 0
+	set ^Config("CodeTidy", "codetidy") = 1
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.ExpansionTestClassLowerCase.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
+	set resultClass = "TestPackage.ExpansionTestClassLowerCase.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
-
-
-    // Run CodeTidy with Pascal-case expansion
-    set ^Config("CodeTidy","codetidy") = 1
-    set ^Config("CodeTidy","capital") = 1
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
-
-    set resultClass = "TestPackage.ExpansionTestClassPascalCase.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 
 
-    // Run CodeTidy with expansion disabled
-    set ^Config("CodeTidy","codetidy") = 0
-    set ^Config("CodeTidy","capital") = 0
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
+	// Run CodeTidy with Pascal-case expansion
+	set ^Config("CodeTidy", "codetidy") = 1
+	set ^Config("CodeTidy", "capital") = 1
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.ExpansionTestClass.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
+	set resultClass = "TestPackage.ExpansionTestClassPascalCase.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 
-    set ^Config("CodeTidy","codetidy") = 1
+
+	// Run CodeTidy with expansion disabled
+	set ^Config("CodeTidy", "codetidy") = 0
+	set ^Config("CodeTidy", "capital") = 0
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.ExpansionTestClass.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+
+	set ^Config("CodeTidy", "codetidy") = 1
 }
 
 Method TestCommentStyleOptions()
 {
-    Set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir_"/../../../../_reference")
-    set referenceClassItemName = "TestPackage.CommentStyleTestClass.cls"
-    set referenceClassName = referenceRoot_"before/"_referenceClassItemName
-    
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.CommentStyleTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
 
-    // Run CodeTidy with lower-case expansion
-    set ^Config("CodeTidy","coscomment")=";"
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-    
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	// Run CodeTidy with lower-case expansion
+	set ^Config("CodeTidy", "coscomment") = ";"
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.CommentStyleTestClassSemicolon.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
+	set resultClass = "TestPackage.CommentStyleTestClassSemicolon.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
-
-
-    // Run CodeTidy with Pascal-case expansion
-    set ^Config("CodeTidy","coscomment")="#;"
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
-
-    set resultClass = "TestPackage.CommentStyleTestClassMacro.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 
 
-    // Run CodeTidy with expansion disabled
-    set ^Config("CodeTidy","coscomment")="//"
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
+	// Run CodeTidy with Pascal-case expansion
+	set ^Config("CodeTidy", "coscomment") = "#;"
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
-    
-    set resultClass = "TestPackage.CommentStyleTestClassForwardSlash.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	set resultClass = "TestPackage.CommentStyleTestClassMacro.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+
+
+	// Run CodeTidy with expansion disabled
+	set ^Config("CodeTidy", "coscomment") = "//"
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	
+	set resultClass = "TestPackage.CommentStyleTestClassForwardSlash.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 }
 
 Method TestSQLPlanOptions()
 {
-    Set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir_"/../../../../_reference")
-    set referenceClassItemName = "TestPackage.SQLPLanTestClass.cls"
-    set referenceClassName = referenceRoot_"before/"_referenceClassItemName
-    
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.SQLPLanTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
 
-    // Run CodeTidy with lower-case expansion
-    set ^Config("CodeTidy","sqlplan")="0"
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-    
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	// Run CodeTidy with lower-case expansion
+	set ^Config("CodeTidy", "sqlplan") = "0"
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.SQLPLanTestClass.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
+	set resultClass = "TestPackage.SQLPLanTestClass.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
-
-
-    // Run CodeTidy with Pascal-case expansion
-    set ^Config("CodeTidy","sqlplan")="1"
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
-
-    set resultClass = "TestPackage.SQLPLanTestClassExplicit.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 
 
-    // Run CodeTidy with expansion disabled
-    set ^Config("CodeTidy","sqlplan")="2"
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
+	// Run CodeTidy with Pascal-case expansion
+	set ^Config("CodeTidy", "sqlplan") = "1"
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.SQLPLanTestClassAlways.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
+	set resultClass = "TestPackage.SQLPLanTestClassExplicit.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+
+
+	// Run CodeTidy with expansion disabled
+	set ^Config("CodeTidy", "sqlplan") = "2"
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.SQLPLanTestClassAlways.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 }
 
 Method TestSQLCaseOptions()
 {
-    Set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir_"/../../../../_reference")
-    set referenceClassItemName = "TestPackage.SQLCaseTestClass.cls"
-    set referenceClassName = referenceRoot_"before/"_referenceClassItemName
-    
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.SQLCaseTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
 
-    // Run CodeTidy with lower-case expansion
-    set ^Config("CodeTidy","sqlcase")=""
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-    
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	// Run CodeTidy with lower-case expansion
+	set ^Config("CodeTidy", "sqlcase") = ""
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.SQLCaseTestClass.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
+	set resultClass = "TestPackage.SQLCaseTestClass.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
-
-
-    // Run CodeTidy with Pascal-case expansion
-    set ^Config("CodeTidy","sqlcase")="L"
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
-
-    set resultClass = "TestPackage.SQLCaseTestClassLowerCase.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 
 
-    // Run CodeTidy with expansion disabled
-    set ^Config("CodeTidy","sqlcase")="U"
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
+	// Run CodeTidy with Pascal-case expansion
+	set ^Config("CodeTidy", "sqlcase") = "L"
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.SQLCaseTestClassUpperCase.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
+	set resultClass = "TestPackage.SQLCaseTestClassLowerCase.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+
+
+	// Run CodeTidy with expansion disabled
+	set ^Config("CodeTidy", "sqlcase") = "U"
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.SQLCaseTestClassUpperCase.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 }
 
 Method TestBraceOptions()
 {
-    Set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir_"/../../../../_reference")
-    set referenceClassItemName = "TestPackage.BraceTestClass.cls"
-    set referenceClassName = referenceRoot_"before/"_referenceClassItemName
-    
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.BraceTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
 
-    // Run CodeTidy with resequencing enabled
-    set ^Config("CodeTidy","brace") = 0
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-    
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	// Run CodeTidy with resequencing enabled
+	set ^Config("CodeTidy", "brace") = 0
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.BraceTestClassDisabled.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
-    
+	set resultClass = "TestPackage.BraceTestClassDisabled.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+	
 
-    // Run CodeTidy with resequencing disabled
-    set ^Config("CodeTidy","brace") = 1
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
+	// Run CodeTidy with resequencing disabled
+	set ^Config("CodeTidy", "brace") = 1
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.BraceTestClassEnabled.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	set resultClass = "TestPackage.BraceTestClassEnabled.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 }
 
 Method TestSpacingOptions()
 {
-    Set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir_"/../../../../_reference")
-    set referenceClassItemName = "TestPackage.SpacingTestClass.cls"
-    set referenceClassName = referenceRoot_"before/"_referenceClassItemName
-    
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.SpacingTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
 
-    // Run CodeTidy with resequencing enabled
-    set ^Config("CodeTidy","coswhitespace") = 0
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
-    
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	// Run CodeTidy with resequencing enabled
+	set ^Config("CodeTidy", "coswhitespace") = 0
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.SpacingTestClassDisabled.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
-    
+	set resultClass = "TestPackage.SpacingTestClassDisabled.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+	
 
-    // Run CodeTidy with resequencing disabled
-    set ^Config("CodeTidy","coswhitespace") = 1
-    Do $$$AssertStatusOK($System.OBJ.Load(referenceClassName), "ck")
+	// Run CodeTidy with resequencing disabled
+	set ^Config("CodeTidy", "coswhitespace") = 1
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 
-    Do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
-    set resultClass = "TestPackage.SpacingTestClassEnabled.cls"
-    Set truthFile = referenceRoot_"after/"_resultClass
-    Set exportFile = referenceRoot_"compare/"_resultClass
-    // Note: this appends an extra newline at the end. "after" files need this.
-    Do $$$AssertStatusOK($System.OBJ.ExportUDL(referenceClassItemName,exportFile))
-    Do $$$AssertFilesSame(exportFile,truthFile,"Files match: "_referenceClassItemName)
-    if ..deleteFiles {
-        Do ##class(%Library.File).Delete(exportFile)
-    }
+	set resultClass = "TestPackage.SpacingTestClassEnabled.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+}
+
+Method TestJSONLinting()
+{
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.JSONBracketMatching.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	// Run CodeTidy with resequencing enabled
+	set ^Config("CodeTidy", "resequence") = 1
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.JSONBracketMatching.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.JSONBracketOneLine.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	// Run CodeTidy with resequencing enabled
+	set ^Config("CodeTidy", "resequence") = 1
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.JSONBracketOneLine.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.JSONIndent.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	// Run CodeTidy with resequencing enabled
+	set ^Config("CodeTidy", "resequence") = 1
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.JSONIndent.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.JSONBracketMixed.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	// Run CodeTidy with resequencing enabled
+	set ^Config("CodeTidy", "resequence") = 1
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.JSONBracketMixed.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 }
 
 Method %OnClose() As %Status
 {
-    do ##class(%Studio.SourceControl.Interface).SourceControlClassSet(..userSourceControl)
-    kill ^Config("CodeTidy")
-    merge ^Config("CodeTidy") = ..userConfig
-    quit $$$OK
+	do ##class(%Studio.SourceControl.Interface).SourceControlClassSet(..userSourceControl)
+	kill ^Config("CodeTidy")
+	merge ^Config("CodeTidy") = ..userConfig
+	quit $$$OK
 }
 
 }

--- a/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
+++ b/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
@@ -512,8 +512,6 @@ Method TestJSONLinting()
 	set referenceClassItemName = "TestPackage.JSONBracketMatching.cls"
 	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
 	
-	// Run CodeTidy with resequencing enabled
-	set ^Config("CodeTidy", "resequence") = 1
 	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 	
 	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
@@ -536,8 +534,6 @@ Method TestJSONLinting()
 	set referenceClassItemName = "TestPackage.JSONBracketOneLine.cls"
 	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
 	
-	// Run CodeTidy with resequencing enabled
-	set ^Config("CodeTidy", "resequence") = 1
 	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 	
 	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
@@ -560,8 +556,6 @@ Method TestJSONLinting()
 	set referenceClassItemName = "TestPackage.JSONIndent.cls"
 	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
 	
-	// Run CodeTidy with resequencing enabled
-	set ^Config("CodeTidy", "resequence") = 1
 	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 	
 	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
@@ -584,8 +578,6 @@ Method TestJSONLinting()
 	set referenceClassItemName = "TestPackage.JSONBracketMixed.cls"
 	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
 	
-	// Run CodeTidy with resequencing enabled
-	set ^Config("CodeTidy", "resequence") = 1
 	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 	
 	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
@@ -608,13 +600,86 @@ Method TestJSONLinting()
 	set referenceClassItemName = "TestPackage.JSONOneDimArray.cls"
 	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
 	
-	// Run CodeTidy with resequencing enabled
-	set ^Config("CodeTidy", "resequence") = 1
 	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
 	
 	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
 	set resultClass = "TestPackage.JSONOneDimArray.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+}
+
+Method TestHTMLIndent()
+{
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.HTMLIndentTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.HTMLIndentTestClass.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+}
+
+Method TestJSIndent()
+{
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.JSIndentTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.JSIndentTestClass.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+}
+
+Method TestBlockComment()
+{
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.BlockCommentTestClass.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.BlockCommentTestClass.cls"
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 

--- a/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
+++ b/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
@@ -603,6 +603,30 @@ Method TestJSONLinting()
 	if ..deleteFiles {
 		do ##class(%Library.File).Delete(exportFile)
 	}
+
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.JSONOneDimArray.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	// Run CodeTidy with resequencing enabled
+	set ^Config("CodeTidy", "resequence") = 1
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.JSONOneDimArray.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
 }
 
 Method %OnClose() As %Status


### PR DESCRIPTION
Added:
- JSON Linting methods to Assistant.cls (JSONLint, NextNonWhitespaceToken)
- Unit tests for JSON array formatting

Fixed:
- Indentation of JSON arrays
- Bracket matching of JSON arrays
- HTML Indentation
- Indentation for embedded blocks using markers
- Indentation for block comments