### PR TITLE
Fixed adding of problematic line breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2023-02-23
+
+### Fixed
+-Fixed insertion of new line even though JSON array was empty
+-Fixed JSON Linting being applied to JSON arrays within arguments of a macro
+
 ## [1.1.4] - 2023-02-07
 
 ### Fixed

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -563,6 +563,10 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
 
     #; Vertical Spacing for JSON Array
     for line=1:1:$Get(tokens,0) {
+        #; For checking if within Macro statement
+        set isMacro = 0
+        set macroParen = 0
+
         set lineTokens = tokens(line)
         set pointer = 0
         set newLineTokens = ""
@@ -572,6 +576,24 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
             if 'isJSON {
                 set oneDimArray = 1
             }
+
+            #; Special case, do nothing if in Macro
+            if type = "Macro" {
+                set isMacro = 1
+            }
+
+            if isMacro {
+                if fragment = ")" {
+                    do $i(macroParen,-1)
+                    if 'macroParen {
+                        set isMacro = 0
+                    }
+                } elseif fragment = "(" {
+                    do $i(macroParen)
+                }
+                if macroParen continue
+            }
+            
 
             #; Handle special rules for line breaks/removing white space
             #; for JSON brackets and delimiters. 
@@ -585,7 +607,17 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                 if (fragment = "{") {
                     if oneDimArray do $i(isJSON)
                     set pointerCopy = pointer
-                    if $listnext(lineTokens,pointerCopy,dummy) {
+                    set nextToken = ..NextNonWhitespaceToken(.tokens,line,lineTokens,pointer,.nextLine,.nextLineTokens,.nextPointer)
+                    set $ListBuild(nextLang, nextType, nextFragment) = nextToken
+                    if nextFragment = "}" {
+                        set newLineTokens = newLineTokens _ $ListBuild(nextToken)
+                        set pointer = nextPointer
+                        set line = nextLine
+                        set lineTokens = nextLineTokens
+                        set token = nextToken
+                        do $i(isJSON,-1)
+                        if 'isJSON set oneDimArray = 0
+                    } elseif $listnext(lineTokens,pointerCopy,dummy) {
                         set newTokens($i(newTokens)) = newLineTokens
                         set newLineTokens = ""
                     }
@@ -625,6 +657,13 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                             set newTokens($i(newTokens)) = newLineTokens
                             set newLineTokens = ""
                         }
+                    } elseif nextToken = $ListBuild("COS","JSON bracket","]") {
+                        set newLineTokens = newLineTokens _ $ListBuild(nextToken)
+                        set line = nextLine
+                        set lineTokens = nextLineTokens
+                        set pointer = nextPointer
+                        set pointerCopy = pointer
+                        do $i(isJSON,-2)
                     }
                 } elseif (fragment = "]") {
                     do $i(isJSON,-2)

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="IRIS" version="26">
 <Document name="isc.codetidy.ZPM"><Module>
   <Name>isc.codetidy</Name>
-  <Version>1.1.4</Version>
+  <Version>1.1.5</Version>
   <Packaging>module</Packaging>
   <Resource Name="pkg.isc.codetidy.PKG" Directory="cls" />
   <Resource Name="pkg.isc.codetidy.CodeTidy.INC" Directory="inc" />

--- a/tests/_reference/after/TestPackage.JSONEmptyArray.cls
+++ b/tests/_reference/after/TestPackage.JSONEmptyArray.cls
@@ -1,0 +1,12 @@
+Class TestPackage.JSONEmptyArray
+{
+
+ClassMethod TestJSONArray()
+{
+    set curly = {}
+    set square = []
+    set fromJSON = {}.%FromJSON()
+}
+
+}
+

--- a/tests/_reference/after/TestPackage.JSONInMacro.cls
+++ b/tests/_reference/after/TestPackage.JSONInMacro.cls
@@ -1,0 +1,10 @@
+Class TestPackage.JSONInMacro Extends %UnitTest.TestCase
+{
+
+Method TestMacroJSON()
+{
+    do $$$AssertEquals({"foo":1,"bar":2}, 2)
+}
+
+}
+

--- a/tests/_reference/before/TestPackage.JSONEmptyArray.cls
+++ b/tests/_reference/before/TestPackage.JSONEmptyArray.cls
@@ -1,0 +1,16 @@
+Class TestPackage.JSONEmptyArray
+{
+
+ClassMethod TestJSONArray()
+{
+    set curly = {
+
+            }
+    set square = [
+        ]
+    set fromJSON = {		
+
+        }.%FromJSON()
+}
+
+}

--- a/tests/_reference/before/TestPackage.JSONInMacro.cls
+++ b/tests/_reference/before/TestPackage.JSONInMacro.cls
@@ -1,0 +1,9 @@
+Class TestPackage.JSONInMacro Extends %UnitTest.TestCase
+{
+
+Method TestMacroJSON()
+{
+    do $$$AssertEquals({"foo":1,      "bar":2}, 2)
+}
+
+}

--- a/tests/_reference/compare/TestPackage.JSONEmptyArray.cls
+++ b/tests/_reference/compare/TestPackage.JSONEmptyArray.cls
@@ -1,0 +1,12 @@
+Class TestPackage.JSONEmptyArray
+{
+
+ClassMethod TestJSONArray()
+{
+    set curly = {}
+    set square = []
+    set fromJSON = {}.%FromJSON()
+}
+
+}
+

--- a/tests/_reference/compare/TestPackage.JSONInMacro.cls
+++ b/tests/_reference/compare/TestPackage.JSONInMacro.cls
@@ -1,0 +1,10 @@
+Class TestPackage.JSONInMacro Extends %UnitTest.TestCase
+{
+
+Method TestMacroJSON()
+{
+    do $$$AssertEquals({"foo":1,"bar":2}, 2)
+}
+
+}
+

--- a/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
+++ b/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
@@ -530,7 +530,6 @@ Method TestJSONLinting()
 		do ##class(%Library.File).Delete(exportFile)
 	}
 
-	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
 	set referenceClassItemName = "TestPackage.JSONBracketOneLine.cls"
 	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
 	
@@ -552,7 +551,6 @@ Method TestJSONLinting()
 		do ##class(%Library.File).Delete(exportFile)
 	}
 
-	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
 	set referenceClassItemName = "TestPackage.JSONIndent.cls"
 	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
 	
@@ -574,7 +572,6 @@ Method TestJSONLinting()
 		do ##class(%Library.File).Delete(exportFile)
 	}
 
-	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
 	set referenceClassItemName = "TestPackage.JSONBracketMixed.cls"
 	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
 	
@@ -596,7 +593,6 @@ Method TestJSONLinting()
 		do ##class(%Library.File).Delete(exportFile)
 	}
 
-	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
 	set referenceClassItemName = "TestPackage.JSONOneDimArray.cls"
 	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
 	
@@ -618,7 +614,6 @@ Method TestJSONLinting()
 		do ##class(%Library.File).Delete(exportFile)
 	}
 
-	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
 	set referenceClassItemName = "TestPackage.JSONNested.cls"
 	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
 	
@@ -627,6 +622,48 @@ Method TestJSONLinting()
 	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
 	set resultClass = "TestPackage.JSONNested.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+
+	set referenceClassItemName = "TestPackage.JSONEmptyArray.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.JSONEmptyArray.cls"
+	set truthFile = referenceRoot _ "after/" _ resultClass
+	set exportFile = referenceRoot _ "compare/" _ resultClass
+
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
+
+	// Note: this appends an extra newline at the end. "after" files need this.
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+
+	set referenceClassItemName = "TestPackage.JSONInMacro.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+	
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
+
+	set resultClass = "TestPackage.JSONInMacro.cls"
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 


### PR DESCRIPTION
Fixed:
- Line breaks being inserted into empty JSON arrays
- JSON Linting being applied to macro arguments causing compilation error

Fixes #33 
Fixes #34 