### PR TITLE
Fix broken README link to ObjectScript Package Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Note: a minimum platform version of InterSystems IRIS 2018.1 is required.
 
 ### Installation: ZPM
 
-If you already have the [ObjectScript Package Manager](https://openexchange.intersystems.com/package/ObjectScript-Package-Manager-2), installation is as easy as:
+If you already have the [ObjectScript Package Manager](https://openexchange.intersystems.com/package/InterSystems-Package-Manager-1), installation is as easy as:
 ```
 zpm "install isc.codetidy"
 ```


### PR DESCRIPTION
Please also update the link at https://openexchange.intersystems.com/package/isc-codetidy