### PR TITLE
Fixed .js file handling during RunAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2024-07-29
+
+### Fixed
+-Fixed .js files in other namespaces' /itemsetsourcelink web app being editing during ##class(pkg.isc.codetidy.Utils).RunAll (#45)
+-Fixed .js files being re-exported without edit during ##class(pkg.isc.codetidy.Utils).RunAll() even though ESLint is disabled so no reason to export (#44)
+
 ## [1.1.5] - 2023-02-23
 
 ### Fixed

--- a/cls/pkg/isc/codetidy/Utils.cls
+++ b/cls/pkg/isc/codetidy/Utils.cls
@@ -159,30 +159,32 @@ ClassMethod RunAll(pOnlyIfInSourceControl As %Boolean = 1) As %Status
 
 		// Run all .js files
 		// Build the spec for StudioOpenDialog
-		set spec = ""
-		set codeNamespace = $namespace
-		set $namespace = "%SYS"
-		set result = ##class(%SQL.Statement).%ExecDirect(,"select * from Security.Applications where NameSpace = ?", codeNamespace)
-		while result.%Next() {
-			// Exclude anything from the itemsetsourcelink web application
-			if result.ID '= "/itemsetsourcelink" {
-				set entry = $extract(result.ID, 2, *)_"/*.js"
-				if spec = "" {
-					set spec = entry
-				} else {
-					set spec = spec_","_entry
+		if ..GetESLintEnabled() {
+			set spec = ""
+			set codeNamespace = $namespace
+			set $namespace = "%SYS"
+			set result = ##class(%SQL.Statement).%ExecDirect(,"select * from Security.Applications where NameSpace = ?", codeNamespace)
+			while result.%Next() {
+				// Exclude anything from the itemsetsourcelink web application
+				if $Extract(result.ID, 1, 18) '= "/itemsetsourcelink" {
+					set entry = $extract(result.ID, 2, *)_"/*.js"
+					if spec = "" {
+						set spec = entry
+					} else {
+						set spec = spec_","_entry
+					}
 				}
 			}
-		}
-		set $namespace = codeNamespace
+			set $namespace = codeNamespace
 
-		// Run StudioOpenDialog to get the .js files
-		set resultSet = ##class(%Library.ResultSet).%New("%RoutineMgr:StudioOpenDialog")
-		$$$ThrowOnError(resultSet.Prepare())
-		$$$ThrowOnError(resultSet.Execute(spec, 1, 1, 0, 1, 0, 0, ""))
-		while resultSet.Next() {
-			set name = resultSet.Data("Name")
-			$$$ThrowOnError(##class(pkg.isc.codetidy.Utils).Run(name, pOnlyIfInSourceControl))
+			// Run StudioOpenDialog to get the .js files
+			set resultSet = ##class(%Library.ResultSet).%New("%RoutineMgr:StudioOpenDialog")
+			$$$ThrowOnError(resultSet.Prepare())
+			$$$ThrowOnError(resultSet.Execute(spec, 1, 1, 0, 1, 0, 0, ""))
+			while resultSet.Next() {
+				set name = resultSet.Data("Name")
+				$$$ThrowOnError(##class(pkg.isc.codetidy.Utils).Run(name, pOnlyIfInSourceControl))
+			}
 		}
 	} catch e {
 		set sc = e.AsStatus()

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="IRIS" version="26">
 <Document name="isc.codetidy.ZPM"><Module>
   <Name>isc.codetidy</Name>
-  <Version>1.1.5</Version>
+  <Version>1.1.6</Version>
   <Packaging>module</Packaging>
   <Resource Name="pkg.isc.codetidy.PKG" Directory="cls" />
   <Resource Name="pkg.isc.codetidy.CodeTidy.INC" Directory="inc" />


### PR DESCRIPTION
-Fixed RunAll queueing js files under secondary /itemsetsourcelink web apps
-Fixed .js files being re-exported even though ESLint is disabled during RunAll