### PR TITLE
Ignore Python Indentation and Fix ForeignKey Resequencing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.7] - 2024-08-20
+
+### Fixed
+-Add Foreign Keys to class items to resequence (#51)
+-Prevented auto-indentation of embedded Python lines until Python linting is implemented (#52)
+
 ## [1.1.6] - 2024-07-29
 
 ### Fixed

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -296,6 +296,9 @@ ClassMethod IndentDocument(InternalName As %String) As %Status
                     $$$ThrowOnError(##class(pkg.isc.codetidy.vartyping.ObjectScriptTokenizer).GetMethodImplementation(classDef.Name, method.Name, .tmpTokens, $namespace))
                     do ..JSONLint(.tmpTokens,method.Implementation,0,.tokens)
                     do method.Implementation.Rewind()
+                } elseif method.Language = "python" {
+                    // TODO Add embedded Python linting
+                    continue
                 }
 
                 #; Run through each line and build a new stream

--- a/cls/pkg/isc/codetidy/SourceGen.cls
+++ b/cls/pkg/isc/codetidy/SourceGen.cls
@@ -16,7 +16,7 @@ ClassMethod ResequenceDocument(InternalName As %String, Export As %Boolean) As %
 		
 		if $isobject(class) {
 			#; Parameters
-			for list = class.Parameters, class.Properties, class.Indices, class.Methods, class.Queries, class.Triggers, class.Storages {
+			for list = class.Parameters, class.Properties, class.ForeignKeys, class.Indices, class.Methods, class.Queries, class.Triggers, class.Storages {
 				set key = ""
 				for {
 					set item = list.GetNext(.key)
@@ -39,12 +39,14 @@ ClassMethod ResequenceDocument(InternalName As %String, Export As %Boolean) As %
 						}
 					} elseif ($classname(item) = "%Dictionary.ParameterDefinition") || ($classname(item) = "%Dictionary.PropertyDefinition") {
 						set weight = 20
-					} elseif ($classname(item) = "%Dictionary.IndexDefinition") {
+					} elseif ($classname(item) = "%Dictionary.ForeignKeyDefinition") {
 						set weight = 30
-					} elseif ($classname(item) = "%Dictionary.MethodDefinition") || ($classname(item) = "%Dictionary.QueryDefinition") {
+					} elseif ($classname(item) = "%Dictionary.IndexDefinition") {
 						set weight = 40
-					} elseif ($classname(item) = "%Dictionary.TriggerDefinition") {
+					} elseif ($classname(item) = "%Dictionary.MethodDefinition") || ($classname(item) = "%Dictionary.QueryDefinition") {
 						set weight = 50
+					} elseif ($classname(item) = "%Dictionary.TriggerDefinition") {
+						set weight = 60
 					} else {
 						set weight = 99
 					}

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="IRIS" version="26">
 <Document name="isc.codetidy.ZPM"><Module>
   <Name>isc.codetidy</Name>
-  <Version>1.1.6</Version>
+  <Version>1.1.7</Version>
   <Packaging>module</Packaging>
   <Resource Name="pkg.isc.codetidy.PKG" Directory="cls" />
   <Resource Name="pkg.isc.codetidy.CodeTidy.INC" Directory="inc" />


### PR DESCRIPTION
-Ignored language = "python" when indenting documents
-Added weight to ForeignKey class members such that they fall between properties and indices