### PR TITLE
Fix comment bugs and resequencing of XDatas and Projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.8] - 2024-08-23
+
+### Fixed
+-Fixed auto indent of comments inside dynamic arrays removing white space (#50)
+-Fixed conversion of #; comments at start of line in routines causing syntax error (#55)
+-Fixed resequencing of Projections and XDatas to give assigned positions (#54)
+
 ## [1.1.7] - 2024-08-20
 
 ### Fixed

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -681,7 +681,7 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                             &&(nextToken = $ListBuild("COS","JSON bracket","{"))))) {
                     set newTokens($i(newTokens)) = newLineTokens
                     set newLineTokens = ""
-                } elseif nextType = "Comment" {
+                } elseif (nextType = "Comment") && (type '= "Comment") {
                     set spaceToken = $ListBuild("COS", "Comment", " ")
                     set newLineTokens = newLineTokens _ $ListBuild(spaceToken)
                 }
@@ -1213,12 +1213,12 @@ ClassMethod IncIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
             // Check for block statements
             set openParNoMarker = $replace(openPar, marker, "")
             // embedded html needs to omit ">" as part of tags i.e. &html< <script> should skip indentation
-            if (openParNoMarker = "&html<") && closePar = ">" {
+            if (openParNoMarker = "&html<") && (closePar = ">") {
                 set openCount = $length(LineText, "&html<") + $length("<") - 1 - $length(LineText, ">")
             } else {
                 set openCount = $length(LineText, openPar) - $length(LineText, closePar)
             }
-            
+
             if openCount > 0 {
                 if openPar '= "/*" {
                     set Handle(openParNoMarker) = $get(Handle(openParNoMarker)) + openCount

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -673,7 +673,6 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                 }
             } elseif (type '= "White Space") && (fragment '= ":") {
                 set nextToken = ..NextNonWhitespaceToken(.tokens,line,lineTokens,pointer,.nextLine,.nextLineTokens,.nextPointer)
-                set nextType = $ListGet(nextToken, 2)
                 set pointerCopy = pointer
                 if (($listnext(lineTokens, pointerCopy, dummy)) 
                     && ((nextToken = $ListBuild("COS","JSON bracket","}"))
@@ -681,16 +680,12 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                             &&(nextToken = $ListBuild("COS","JSON bracket","{"))))) {
                     set newTokens($i(newTokens)) = newLineTokens
                     set newLineTokens = ""
-                } elseif (nextType = "Comment") && (type '= "Comment") {
-                    set spaceToken = $ListBuild("COS", "Comment", " ")
-                    set newLineTokens = newLineTokens _ $ListBuild(spaceToken)
                 }
             }
         }
         if ((newLineTokens '= "") || ('isJSON)) {
             set newTokens($i(newTokens)) = newLineTokens
         }
-        
     }
 
     // Horizontal Spacing for JSON Arrays
@@ -753,6 +748,12 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                 }
                 if type '= "White Space" {
                     set newLineTokens = newLineTokens _ $ListBuild(token)
+                } else {
+                    set nextToken = ..NextNonWhitespaceToken(.tokens,line,lineTokens,pointer,.nextLine,.nextLineTokens,.nextPointer)
+                    set nextType = $ListGet(nextToken, 2)
+                    if nextType = "Comment" {
+                        set newLineTokens = newLineTokens _ $ListBuild(token)
+                    }
                 }
             } else {
                 set newLineTokens = newLineTokens _ $ListBuild(token)

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -671,8 +671,9 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                 } elseif (fragment = "]") {
                     do $i(isJSON,-2)
                 }
-            } elseif (type '= "White Space") && (fragment '= ":"){
+            } elseif (type '= "White Space") && (fragment '= ":") {
                 set nextToken = ..NextNonWhitespaceToken(.tokens,line,lineTokens,pointer,.nextLine,.nextLineTokens,.nextPointer)
+                set nextType = $ListGet(nextToken, 2)
                 set pointerCopy = pointer
                 if (($listnext(lineTokens, pointerCopy, dummy)) 
                     && ((nextToken = $ListBuild("COS","JSON bracket","}"))
@@ -680,6 +681,9 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                             &&(nextToken = $ListBuild("COS","JSON bracket","{"))))) {
                     set newTokens($i(newTokens)) = newLineTokens
                     set newLineTokens = ""
+                } elseif nextType = "Comment" {
+                    set spaceToken = $ListBuild("COS", "Comment", " ")
+                    set newLineTokens = newLineTokens _ $ListBuild(spaceToken)
                 }
             }
         }
@@ -717,7 +721,7 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
         set newLineTokens = ""
         while $listnext(lineTokens, pointer, token) {
             set $ListBuild(lang, type, fragment) = token
-
+            
             #; Number of opening [ determine how many closing ] are needed
             #; to exit the array and then be outside JSON
             if token = $ListBuild("COS","JSON bracket","[") {
@@ -1208,7 +1212,13 @@ ClassMethod IncIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
 
             // Check for block statements
             set openParNoMarker = $replace(openPar, marker, "")
-            set openCount = $length(LineText, openPar) - $length(LineText, closePar)
+            // embedded html needs to omit ">" as part of tags i.e. &html< <script> should skip indentation
+            if (openParNoMarker = "&html<") && closePar = ">" {
+                set openCount = $length(LineText, "&html<") + $length("<") - 1 - $length(LineText, ">")
+            } else {
+                set openCount = $length(LineText, openPar) - $length(LineText, closePar)
+            }
+            
             if openCount > 0 {
                 if openPar '= "/*" {
                     set Handle(openParNoMarker) = $get(Handle(openParNoMarker)) + openCount

--- a/cls/pkg/isc/codetidy/CodeTidy.cls
+++ b/cls/pkg/isc/codetidy/CodeTidy.cls
@@ -816,6 +816,10 @@ ClassMethod ParseFragmentCOSComment(ByRef last, ByRef this, ByRef next, ByRef co
 		if ##class(pkg.isc.codetidy.Utils).GetObjectScriptWhiteSpace() {
 			if $extract(conv("Frag"), 1, 2) = "//", $extract(conv("Frag"), 3) '= " " set conv("Frag") = cosComment _ " " _ $extract(conv("Frag"), 3, *)
 		}
+		// Only #; and ##; comments are allowed at start of line without indent
+		if ($extract(this("Frag")) = "#") && ($extract(conv("Frag")) '= "#") && ($extract(last("Frag")) = "") {
+			set conv("Frag") = " "_conv("Frag")
+		}
 	}
 }
 

--- a/cls/pkg/isc/codetidy/SourceGen.cls
+++ b/cls/pkg/isc/codetidy/SourceGen.cls
@@ -16,7 +16,7 @@ ClassMethod ResequenceDocument(InternalName As %String, Export As %Boolean) As %
 		
 		if $isobject(class) {
 			#; Parameters
-			for list = class.Parameters, class.Properties, class.ForeignKeys, class.Indices, class.Methods, class.Queries, class.Triggers, class.Storages {
+			for list = class.Projections, class.Parameters, class.Properties, class.ForeignKeys, class.Indices, class.Methods, class.Queries, class.Triggers, class.XDatas, class.Storages {
 				set key = ""
 				for {
 					set item = list.GetNext(.key)
@@ -25,28 +25,35 @@ ClassMethod ResequenceDocument(InternalName As %String, Export As %Boolean) As %
 					if item.Name = "SrcVer" {
 						#; SrcVer to be shown at the top.
 						set weight = 0
+					} elseif ($classname(item) = "%Dictionary.ProjectionDefinition") {
+						#; Other than SrcVer Projections should come first
+						set weight = 10
 					} elseif ($classname(item) = "%Dictionary.ParameterDefinition") && (item.Name = $zconvert(item.Name,"U")) {
 						#; Mixed case parameters are sometimes used in relation to a property.
 						#; In these cases it the parameter may be kept with the property.
 						if $extract(item.Name,1,7) = "SQLDATE" {
 							#; SQLDATE parameters show after other SQL* parameters
-							set weight = 11
+							set weight = 21
 						} elseif $extract(item.Name,1,3) = "SQL" {
 							#; SQLCODE, SQLDESCRIPTION, SQLROWID are used to identify records.
-							set weight = 10
+							set weight = 20
 						} else {
-							set weight = 15
+							set weight = 25
 						}
 					} elseif ($classname(item) = "%Dictionary.ParameterDefinition") || ($classname(item) = "%Dictionary.PropertyDefinition") {
-						set weight = 20
-					} elseif ($classname(item) = "%Dictionary.ForeignKeyDefinition") {
 						set weight = 30
-					} elseif ($classname(item) = "%Dictionary.IndexDefinition") {
+					} elseif ($classname(item) = "%Dictionary.ForeignKeyDefinition") {
 						set weight = 40
-					} elseif ($classname(item) = "%Dictionary.MethodDefinition") || ($classname(item) = "%Dictionary.QueryDefinition") {
+					} elseif ($classname(item) = "%Dictionary.IndexDefinition") {
 						set weight = 50
-					} elseif ($classname(item) = "%Dictionary.TriggerDefinition") {
+					} elseif ($classname(item) = "%Dictionary.MethodDefinition") || ($classname(item) = "%Dictionary.QueryDefinition") {
 						set weight = 60
+					} elseif ($classname(item) = "%Dictionary.TriggerDefinition") {
+						set weight = 70
+					} elseif $classname(item) = "%Dictionary.XDataDefinition" {
+						set weight = 80
+					} elseif ($classname(item) = "") {
+						set weight = 90
 					} else {
 						set weight = 99
 					}

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="IRIS" version="26">
 <Document name="isc.codetidy.ZPM"><Module>
   <Name>isc.codetidy</Name>
-  <Version>1.1.7</Version>
+  <Version>1.1.8</Version>
   <Packaging>module</Packaging>
   <Resource Name="pkg.isc.codetidy.PKG" Directory="cls" />
   <Resource Name="pkg.isc.codetidy.CodeTidy.INC" Directory="inc" />


### PR DESCRIPTION
This addresses syntax error with substituting comment styles starting with "#" at start of lines (#55), removal of whitespace before comments inside of json arrays(#50), and adds dedicated resequence logic for remaining class members(#54).