### PR TITLE
Prevent CodeTidy from Editing Whitespace in Macro Call Arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.9] - 2024-12-05
+
+### Fixed
+-Fixed spaces being added to delimeters in macro calls (#58)
+
 ## [1.1.8] - 2024-08-23
 
 ### Fixed

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -681,7 +681,7 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                             &&(nextToken = $ListBuild("COS","JSON bracket","{"))))) {
                     set newTokens($i(newTokens)) = newLineTokens
                     set newLineTokens = ""
-                } elseif nextType = "Comment" {
+                } elseif (nextType = "Comment") && (type '= "Comment") {
                     set spaceToken = $ListBuild("COS", "Comment", " ")
                     set newLineTokens = newLineTokens _ $ListBuild(spaceToken)
                 }
@@ -1213,12 +1213,12 @@ ClassMethod IncIndent(ByRef Handle As %Library.Binary, LineText As %String, Lang
             // Check for block statements
             set openParNoMarker = $replace(openPar, marker, "")
             // embedded html needs to omit ">" as part of tags i.e. &html< <script> should skip indentation
-            if (openParNoMarker = "&html<") && closePar = ">" {
+            if (openParNoMarker = "&html<") && (closePar = ">") {
                 set openCount = $length(LineText, "&html<") + $length("<") - 1 - $length(LineText, ">")
             } else {
                 set openCount = $length(LineText, openPar) - $length(LineText, closePar)
             }
-            
+
             if openCount > 0 {
                 if openPar '= "/*" {
                     set Handle(openParNoMarker) = $get(Handle(openParNoMarker)) + openCount

--- a/cls/pkg/isc/codetidy/Assistant.cls
+++ b/cls/pkg/isc/codetidy/Assistant.cls
@@ -673,7 +673,6 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                 }
             } elseif (type '= "White Space") && (fragment '= ":") {
                 set nextToken = ..NextNonWhitespaceToken(.tokens,line,lineTokens,pointer,.nextLine,.nextLineTokens,.nextPointer)
-                set nextType = $ListGet(nextToken, 2)
                 set pointerCopy = pointer
                 if (($listnext(lineTokens, pointerCopy, dummy)) 
                     && ((nextToken = $ListBuild("COS","JSON bracket","}"))
@@ -681,16 +680,12 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                             &&(nextToken = $ListBuild("COS","JSON bracket","{"))))) {
                     set newTokens($i(newTokens)) = newLineTokens
                     set newLineTokens = ""
-                } elseif (nextType = "Comment") && (type '= "Comment") {
-                    set spaceToken = $ListBuild("COS", "Comment", " ")
-                    set newLineTokens = newLineTokens _ $ListBuild(spaceToken)
                 }
             }
         }
         if ((newLineTokens '= "") || ('isJSON)) {
             set newTokens($i(newTokens)) = newLineTokens
         }
-        
     }
 
     // Horizontal Spacing for JSON Arrays
@@ -753,6 +748,12 @@ ClassMethod JSONLint(ByRef tokens, sourceStream As %Stream.Object, isRoutine As 
                 }
                 if type '= "White Space" {
                     set newLineTokens = newLineTokens _ $ListBuild(token)
+                } else {
+                    set nextToken = ..NextNonWhitespaceToken(.tokens,line,lineTokens,pointer,.nextLine,.nextLineTokens,.nextPointer)
+                    set nextType = $ListGet(nextToken, 2)
+                    if nextType = "Comment" {
+                        set newLineTokens = newLineTokens _ $ListBuild(token)
+                    }
                 }
             } else {
                 set newLineTokens = newLineTokens _ $ListBuild(token)

--- a/cls/pkg/isc/codetidy/CodeTidy.cls
+++ b/cls/pkg/isc/codetidy/CodeTidy.cls
@@ -172,7 +172,7 @@ ClassMethod ProcessStream(ByRef instream As %AbstractStream, lang As %String = "
 	set (last("LineStripped"), conv("LineStripped")) = ""
 	set this("Indent") = 0, next("Indent") = 0
 	set this("SyntaxStream") = outstream, this("AtEnd") = 0
-	set conv("PostConditional") = 0, conv("JSSwitch") = 0, conv("JSONSwitch") = 0, conv("PatternMatch") = 0
+	set conv("PostConditional") = 0, conv("JSSwitch") = 0, conv("JSONSwitch") = 0, conv("PatternMatch") = 0, conv("MacroSwitch") = 0
 	set conv("CodeStream") = instream
 
 	if ##class(pkg.isc.codetidy.Utils).GetAddSQLPlan() {
@@ -491,6 +491,27 @@ ClassMethod ParseFragmentCOS(ByRef last, ByRef this, ByRef next, ByRef conv)
 			do ..ApplyIndentation(.this, .next, .conv, "({[", "]})")
 		}
 	}
+
+	// Macro detection
+	if (this("Type") = $$$COSMacro) {
+		set conv("MacroSwitch") = 1
+	}
+
+	if (this("Type") = $$$COSDelimiter) && $get(conv("MacroSwitch")) {
+		if this("Frag") = "(" {
+			set conv("MacroDepth") = $get(conv("MacroDepth")) + 1
+		} elseif this("Frag") = ")" {
+			set conv("MacroDepth") = $get(conv("MacroDepth")) - 1
+		}
+		if '$get(conv("MacroDepth")) {
+			set conv("MacroSwitch") = 0
+		}
+	}
+
+	if ((next("Type") = $$$COSWhiteSpace) || (next("Lang") = "\n")) && $get(conv("MacroSwitch")) && '$get(conv("MacroDepth")) {
+		set conv("MacroSwitch") = 0
+	}
+
 	// Embedding Languages
 	if (this("Type") = $$$COSEmbeddingOpen) {
 		set this("Type") = last("Type")
@@ -781,7 +802,7 @@ ClassMethod ParseFragmentCOS(ByRef last, ByRef this, ByRef next, ByRef conv)
 		set conv("Frag") = $zconvert(this("Frag"), "L")
 		
 		if ##class(pkg.isc.codetidy.Utils).GetObjectScriptWhiteSpace() {
-			if ('conv("PatternMatch")) && (conv("Frag") = ",") {
+			if ('conv("PatternMatch")) && (conv("Frag") = ",") && '$get(conv("MacroDepth")) {
 				// Include whitespace before the next parameter.
 				if next("Type") '= $$$COSWhiteSpace set conv("Frag") = conv("Frag") _ " "
 			}

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 <Export generator="IRIS" version="26">
 <Document name="isc.codetidy.ZPM"><Module>
   <Name>isc.codetidy</Name>
-  <Version>1.1.8</Version>
+  <Version>1.1.9</Version>
   <Packaging>module</Packaging>
   <Resource Name="pkg.isc.codetidy.PKG" Directory="cls" />
   <Resource Name="pkg.isc.codetidy.CodeTidy.INC" Directory="inc" />

--- a/tests/_reference/after/TestPackage.AutoTweakTestClassDisabled.cls
+++ b/tests/_reference/after/TestPackage.AutoTweakTestClassDisabled.cls
@@ -12,4 +12,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.AutoTweakTestClassEnabled.cls
+++ b/tests/_reference/after/TestPackage.AutoTweakTestClassEnabled.cls
@@ -12,4 +12,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.BlockCommentTestClass.cls
+++ b/tests/_reference/after/TestPackage.BlockCommentTestClass.cls
@@ -43,4 +43,3 @@ Method BlockCommentTest()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.BraceTestClassDisabled.cls
+++ b/tests/_reference/after/TestPackage.BraceTestClassDisabled.cls
@@ -14,4 +14,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.BraceTestClassEnabled.cls
+++ b/tests/_reference/after/TestPackage.BraceTestClassEnabled.cls
@@ -20,4 +20,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.CapitalOffTestClass.cls
+++ b/tests/_reference/after/TestPackage.CapitalOffTestClass.cls
@@ -9,4 +9,3 @@ Method TestCapital()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.CapitalOnTestClass.cls
+++ b/tests/_reference/after/TestPackage.CapitalOnTestClass.cls
@@ -9,4 +9,3 @@ Method TestCapital()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.CommentStyleTestClassForwardSlash.cls
+++ b/tests/_reference/after/TestPackage.CommentStyleTestClassForwardSlash.cls
@@ -22,4 +22,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.CommentStyleTestClassMacro.cls
+++ b/tests/_reference/after/TestPackage.CommentStyleTestClassMacro.cls
@@ -22,4 +22,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.CommentStyleTestClassSemicolon.cls
+++ b/tests/_reference/after/TestPackage.CommentStyleTestClassSemicolon.cls
@@ -22,4 +22,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.ExpansionTestClass.cls
+++ b/tests/_reference/after/TestPackage.ExpansionTestClass.cls
@@ -21,4 +21,3 @@ Method MethodB()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.ExpansionTestClassLowerCase.cls
+++ b/tests/_reference/after/TestPackage.ExpansionTestClassLowerCase.cls
@@ -23,4 +23,3 @@ Method MethodB()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.ExpansionTestClassPascalCase.cls
+++ b/tests/_reference/after/TestPackage.ExpansionTestClassPascalCase.cls
@@ -23,4 +23,3 @@ Method MethodB()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.HTMLIndentTestClass.cls
+++ b/tests/_reference/after/TestPackage.HTMLIndentTestClass.cls
@@ -80,4 +80,3 @@ Method HTMLMarker()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.IndentationTestClass.cls
+++ b/tests/_reference/after/TestPackage.IndentationTestClass.cls
@@ -27,4 +27,3 @@ Method MethodB()
 Parameter ABC = "Param";
 
 }
-

--- a/tests/_reference/after/TestPackage.IndentationTestClassSpaces.cls
+++ b/tests/_reference/after/TestPackage.IndentationTestClassSpaces.cls
@@ -27,4 +27,3 @@ Method MethodB()
 Parameter ABC = "Param";
 
 }
-

--- a/tests/_reference/after/TestPackage.IndentationTestClassTabs.cls
+++ b/tests/_reference/after/TestPackage.IndentationTestClassTabs.cls
@@ -27,4 +27,3 @@ Method MethodB()
 Parameter ABC = "Param";
 
 }
-

--- a/tests/_reference/after/TestPackage.JSIndentTestClass.cls
+++ b/tests/_reference/after/TestPackage.JSIndentTestClass.cls
@@ -107,4 +107,3 @@ Method JavaScriptAbbrev()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.JSONBracketMatching.cls
+++ b/tests/_reference/after/TestPackage.JSONBracketMatching.cls
@@ -12,4 +12,3 @@ ClassMethod TestJSONArray() As %Status
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.JSONBracketMixed.cls
+++ b/tests/_reference/after/TestPackage.JSONBracketMixed.cls
@@ -12,4 +12,3 @@ ClassMethod TestJSONArray() As %Status
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.JSONBracketOneLine.cls
+++ b/tests/_reference/after/TestPackage.JSONBracketOneLine.cls
@@ -12,4 +12,3 @@ ClassMethod TestJSONArray() As %Status
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.JSONEmptyArray.cls
+++ b/tests/_reference/after/TestPackage.JSONEmptyArray.cls
@@ -9,4 +9,3 @@ ClassMethod TestJSONArray()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.JSONInMacro.cls
+++ b/tests/_reference/after/TestPackage.JSONInMacro.cls
@@ -7,4 +7,3 @@ Method TestMacroJSON()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.JSONIndent.cls
+++ b/tests/_reference/after/TestPackage.JSONIndent.cls
@@ -12,4 +12,3 @@ ClassMethod TestJSONArray() As %Status
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.JSONNested.cls
+++ b/tests/_reference/after/TestPackage.JSONNested.cls
@@ -50,4 +50,3 @@ Method squareArrayInCurlyArray()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.JSONOneDimArray.cls
+++ b/tests/_reference/after/TestPackage.JSONOneDimArray.cls
@@ -11,4 +11,3 @@ ClassMethod TestJSONArray() As %Status
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.MacroCommentOffMacroTestClass.cls
+++ b/tests/_reference/after/TestPackage.MacroCommentOffMacroTestClass.cls
@@ -14,4 +14,3 @@ Method TestMethod()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.MacroCommentOffSemicolon.cls
+++ b/tests/_reference/after/TestPackage.MacroCommentOffSemicolon.cls
@@ -14,4 +14,3 @@ Method TestMethod()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.MacroCommentOffSlashTestClass.cls
+++ b/tests/_reference/after/TestPackage.MacroCommentOffSlashTestClass.cls
@@ -14,4 +14,3 @@ Method TestMethod()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.MacroCommentOnMacroTestClass.cls
+++ b/tests/_reference/after/TestPackage.MacroCommentOnMacroTestClass.cls
@@ -14,4 +14,3 @@ Method TestMethod()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.MacroCommentOnSemicolon.cls
+++ b/tests/_reference/after/TestPackage.MacroCommentOnSemicolon.cls
@@ -14,4 +14,3 @@ Method TestMethod()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.MacroCommentOnSlashTestClass.cls
+++ b/tests/_reference/after/TestPackage.MacroCommentOnSlashTestClass.cls
@@ -14,4 +14,3 @@ Method TestMethod()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.MacroMultiArg.cls
+++ b/tests/_reference/after/TestPackage.MacroMultiArg.cls
@@ -1,0 +1,19 @@
+Class TestPackage.MacroMultiArg Extends %RegisteredObject
+{
+
+ClassMethod TidyArgsInMethods()
+{
+	set a = 4
+	set b = 5
+	set b = ..DoNotTidyMacroArgs(a, b) // this should add spacing between ',' and b
+	write b
+}
+
+ClassMethod DoNotTidyMacroArgs(foo, bar) As %String
+{
+	#define macro2args(%x, %y) set %y = %x // spacing can be applied to the definition of a macro as well
+	$$$macro2args(foo,bar) // macro call should not adjust spacing
+	return bar
+}
+
+}

--- a/tests/_reference/after/TestPackage.MacroMultiArg.cls
+++ b/tests/_reference/after/TestPackage.MacroMultiArg.cls
@@ -3,17 +3,17 @@ Class TestPackage.MacroMultiArg Extends %RegisteredObject
 
 ClassMethod TidyArgsInMethods()
 {
-	set a = 4
-	set b = 5
-	set b = ..DoNotTidyMacroArgs(a, b) // this should add spacing between ',' and b
-	write b
+    set a = 4
+    set b = 5
+    set b = ..DoNotTidyMacroArgs(a, b) // this should add spacing between ',' and b
+    write b
 }
 
 ClassMethod DoNotTidyMacroArgs(foo, bar) As %String
 {
-	#define macro2args(%x, %y) set %y = %x // spacing can be applied to the definition of a macro as well
-	$$$macro2args(foo,bar) // macro call should not adjust spacing
-	return bar
+    #define macro2args(%x, %y) set %y = %x // spacing can be applied to the definition of a macro as well
+    $$$macro2args(foo,bar) // macro call should not adjust spacing
+    return bar
 }
 
 }

--- a/tests/_reference/after/TestPackage.ResequenceTestClassDisabled.cls
+++ b/tests/_reference/after/TestPackage.ResequenceTestClassDisabled.cls
@@ -18,4 +18,3 @@ Method MethodB()
 Parameter ABC = "Param";
 
 }
-

--- a/tests/_reference/after/TestPackage.ResequenceTestClassEnabled.cls
+++ b/tests/_reference/after/TestPackage.ResequenceTestClassEnabled.cls
@@ -18,4 +18,3 @@ Method MethodB()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.SQLCaseTestClass.cls
+++ b/tests/_reference/after/TestPackage.SQLCaseTestClass.cls
@@ -27,4 +27,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.SQLCaseTestClassLowerCase.cls
+++ b/tests/_reference/after/TestPackage.SQLCaseTestClassLowerCase.cls
@@ -27,4 +27,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.SQLCaseTestClassUpperCase.cls
+++ b/tests/_reference/after/TestPackage.SQLCaseTestClassUpperCase.cls
@@ -27,4 +27,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.SQLPLanTestClass.cls
+++ b/tests/_reference/after/TestPackage.SQLPLanTestClass.cls
@@ -22,4 +22,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.SQLPLanTestClassAlways.cls
+++ b/tests/_reference/after/TestPackage.SQLPLanTestClassAlways.cls
@@ -35,4 +35,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.SQLPLanTestClassExplicit.cls
+++ b/tests/_reference/after/TestPackage.SQLPLanTestClassExplicit.cls
@@ -27,4 +27,3 @@ Method MethodA()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.SpacingTestClassDisabled.cls
+++ b/tests/_reference/after/TestPackage.SpacingTestClassDisabled.cls
@@ -25,4 +25,3 @@ Method MethodB()
 }
 
 }
-

--- a/tests/_reference/after/TestPackage.SpacingTestClassEnabled.cls
+++ b/tests/_reference/after/TestPackage.SpacingTestClassEnabled.cls
@@ -25,4 +25,3 @@ Method MethodB()
 }
 
 }
-

--- a/tests/_reference/before/TestPackage.MacroMultiArg.cls
+++ b/tests/_reference/before/TestPackage.MacroMultiArg.cls
@@ -1,0 +1,19 @@
+Class TestPackage.MacroMultiArg Extends %RegisteredObject
+{
+
+ClassMethod TidyArgsInMethods()
+{
+	set a = 4
+	set b = 5
+	set b = ..DoNotTidyMacroArgs(a,b) // this should add spacing between ',' and b
+	w b
+}
+
+ClassMethod DoNotTidyMacroArgs(foo, bar) As %String
+{
+	#define macro2args(%x,%y) set %y = %x // spacing can be applied to the definition of a macro as well
+	$$$macro2args(foo,bar) // macro call should not adjust spacing
+	return bar
+}
+
+}

--- a/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
+++ b/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
@@ -51,7 +51,7 @@ Method TestResequenceOptions()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -68,7 +68,7 @@ Method TestResequenceOptions()
 	set resultClass = "TestPackage.ResequenceTestClassDisabled.cls"
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -91,7 +91,7 @@ Method TestIndentationOptions()
 	set resultClass = "TestPackage.IndentationTestClassSpaces.cls"
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -107,7 +107,7 @@ Method TestIndentationOptions()
 	set resultClass = "TestPackage.IndentationTestClassTabs.cls"
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -123,7 +123,7 @@ Method TestIndentationOptions()
 	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 	set truthFile = referenceRoot _ "after/" _ referenceClassItemName
 	set exportFile = referenceRoot _ "compare/" _ referenceClassItemName
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -150,7 +150,7 @@ Method TestAutoTweakOptions()
 	set resultClass = "TestPackage.AutoTweakTestClassEnabled.cls"
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -167,7 +167,7 @@ Method TestAutoTweakOptions()
 	set resultClass = "TestPackage.AutoTweakTestClassDisabled.cls"
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -193,7 +193,7 @@ Method TestExpansionOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -212,7 +212,7 @@ Method TestExpansionOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -231,7 +231,7 @@ Method TestExpansionOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -258,7 +258,7 @@ Method TestCommentStyleOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -276,7 +276,7 @@ Method TestCommentStyleOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -294,7 +294,7 @@ Method TestCommentStyleOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -319,7 +319,7 @@ Method TestSQLPlanOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -337,7 +337,7 @@ Method TestSQLPlanOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -355,7 +355,7 @@ Method TestSQLPlanOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -380,7 +380,7 @@ Method TestSQLCaseOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -398,7 +398,7 @@ Method TestSQLCaseOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -416,7 +416,7 @@ Method TestSQLCaseOptions()
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -440,7 +440,7 @@ Method TestBraceOptions()
 	set resultClass = "TestPackage.BraceTestClassDisabled.cls"
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -457,7 +457,7 @@ Method TestBraceOptions()
 	set resultClass = "TestPackage.BraceTestClassEnabled.cls"
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -481,7 +481,7 @@ Method TestSpacingOptions()
 	set resultClass = "TestPackage.SpacingTestClassDisabled.cls"
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -498,7 +498,7 @@ Method TestSpacingOptions()
 	set resultClass = "TestPackage.SpacingTestClassEnabled.cls"
 	set truthFile = referenceRoot _ "after/" _ resultClass
 	set exportFile = referenceRoot _ "compare/" _ resultClass
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -523,7 +523,7 @@ Method TestJSONLinting()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -544,7 +544,7 @@ Method TestJSONLinting()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -565,7 +565,7 @@ Method TestJSONLinting()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -586,7 +586,7 @@ Method TestJSONLinting()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -607,7 +607,7 @@ Method TestJSONLinting()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -628,7 +628,7 @@ Method TestJSONLinting()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -670,7 +670,7 @@ Method TestJSONLinting()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -695,7 +695,7 @@ Method TestHTMLIndent()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -720,7 +720,7 @@ Method TestJSIndent()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -745,7 +745,7 @@ Method TestRoutine()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -770,7 +770,7 @@ Method TestBlockComment()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -800,7 +800,7 @@ Method TestCapital()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -827,7 +827,7 @@ Method TestCapital()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -859,7 +859,7 @@ Method TestUseMacroComment()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -878,7 +878,7 @@ Method TestUseMacroComment()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -897,7 +897,7 @@ Method TestUseMacroComment()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -917,7 +917,7 @@ Method TestUseMacroComment()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -936,7 +936,7 @@ Method TestUseMacroComment()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -955,7 +955,7 @@ Method TestUseMacroComment()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {
@@ -965,6 +965,35 @@ Method TestUseMacroComment()
 	set ^Config("CodeTidy", "tweak") = oldTweak
 	set ^Config("CodeTidy", "usemacrocomments") = oldUseMacro
 	set ^Config("CodeTidy", "coscomment") = oldCommentStyle
+}
+
+Method TestMacroMultiArg()
+{
+	// turn on white space tidying for function arguments
+	set oldCodeTidy = $get(^Config("CodeTidy","codeitdy"))
+	set ^Config("CodeTidy","codetidy") = 1
+
+	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
+	set referenceClassItemName = "TestPackage.MacroMultiArg.cls"
+	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+
+	set truthFile = referenceRoot _ "after/" _ referenceClassItemName
+	set exportFile = referenceRoot _ "compare/" _ referenceClassItemName
+
+	set currentDir = ..Manager.CurrentDir
+	zwrite currentDir, referenceRoot, exportFile
+
+	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
+	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
+	if ..deleteFiles {
+		do ##class(%Library.File).Delete(exportFile)
+	}
+
+	if oldCodeTidy '= "" {
+		set ^Config("CodeTidy", "codetidy") = oldCodeTidy
+	} else {
+		kill ^Config("CodeTidy", "codetidy")
+	}
 }
 
 Method %OnClose() As %Status

--- a/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
+++ b/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
@@ -969,13 +969,15 @@ Method TestUseMacroComment()
 
 Method TestMacroMultiArg()
 {
-	// turn on white space tidying for function arguments
-	set oldCodeTidy = $get(^Config("CodeTidy","codeitdy"))
-	set ^Config("CodeTidy","codetidy") = 1
-
 	set referenceRoot = ##class(%Library.File).NormalizeDirectory(..Manager.CurrentDir _ "/../../../../_reference")
 	set referenceClassItemName = "TestPackage.MacroMultiArg.cls"
 	set referenceClassName = referenceRoot _ "before/" _ referenceClassItemName
+
+	// turn on white space tidying for function arguments
+	set oldCodeTidy = $get(^Config("CodeTidy","codeitdy"))
+	set ^Config("CodeTidy","codetidy") = 1
+	do $$$AssertStatusOK($system.OBJ.Load(referenceClassName), "ck")
+	do $$$AssertStatusOK(##class(pkg.isc.codetidy.Utils).Run(referenceClassItemName))
 
 	set truthFile = referenceRoot _ "after/" _ referenceClassItemName
 	set exportFile = referenceRoot _ "compare/" _ referenceClassItemName

--- a/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
+++ b/tests/pkg/isc/codetidy/test/ReferenceClasses.cls
@@ -649,7 +649,7 @@ Method TestJSONLinting()
 	set currentDir = ..Manager.CurrentDir
 	zwrite currentDir, referenceRoot, exportFile
 
-	// Note: this appends an extra newline at the end. "after" files need this.
+	// In pre 2024.1.2 this adds an additional newline, breaking unit tests. Local development should be against latest IRIS version.
 	do $$$AssertStatusOK($system.OBJ.ExportUDL(referenceClassItemName, exportFile))
 	do $$$AssertFilesSame(exportFile, truthFile, "Files match: " _ referenceClassItemName)
 	if ..deleteFiles {


### PR DESCRIPTION
Address #58 and also includes Unit Test demonstrating new behavior